### PR TITLE
Revert: Remove apify-cli global installation and restore APIFY environment filtering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,6 @@ RUN apt-get update && apt-get install -y \
 # Install tsx globally for TypeScript execution in execute-code endpoint
 RUN npm install -g tsx
 
-# Install Apify CLI globally for Agent access
-RUN npm install -g apify-cli
-
 # Create sandbox directory for operations
 RUN mkdir -p /sandbox && chmod 755 /sandbox
 

--- a/README.md
+++ b/README.md
@@ -92,29 +92,6 @@ Specify dependencies to install via Actor input:
 
 Dependencies are installed during Actor startup before any code execution, allowing your code to immediately use them.
 
-### Pre-installed Global Tools
-
-The sandbox includes the following globally available tools:
-
-- **Apify CLI** (`apify`): Command-line interface for Apify platform operations
-    - Full access to APIFY_TOKEN via environment variables for authentication
-    - Helps manage the Apify cloud platform and develop, build, and deploy Actors
-    - **Most important use cases:**
-        - **Execute Actors**: `apify call <actor-name>` to run other Actors remotely and retrieve results
-        - **Deploy Actors**: `apify push` to deploy your Actor code to the Apify platform
-        - **Manage Runs**: View run status, download outputs, and monitor Actor execution
-        - **Work with Datasets**: Manage structured data storage for outputs
-        - **Create Projects**: `apify create` to scaffold new Actor projects from templates
-        - **Account Management**: `apify info` to view account details, `apify login/logout` for authentication
-    - Example commands:
-        ```bash
-        apify call my-scraper --input '{"url":"https://example.com"}'
-        apify push
-        apify pull my-actor
-        apify info
-        ```
-- **tsx**: TypeScript executor for direct TypeScript execution in Node.js
-
 ### Customization with Init Script
 
 Provide a bash script via the "Initialization Script" input to customize the sandbox:

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -124,10 +124,9 @@ export const initializePythonEnvironment = async (): Promise<void> => {
         log.debug('Creating Python venv', { path: EXECUTION_DIRS.PYTHON_VENV });
 
         // Create a clean environment without PYTHONHOME/VIRTUAL_ENV to prevent conflicts
-        // TODO: Consider reworking this to simplify environment handling for venv creation
         const cleanEnv: NodeJS.ProcessEnv = {};
         Object.keys(process.env).forEach((key) => {
-            if (key !== 'PYTHONHOME' && key !== 'VIRTUAL_ENV') {
+            if (!key.startsWith('APIFY_') && key !== 'PYTHONHOME' && key !== 'VIRTUAL_ENV') {
                 cleanEnv[key] = process.env[key];
             }
         });
@@ -330,7 +329,14 @@ export const setupExecutionEnvironment = async (input: {
  * Returns environment with paths to Python venv and Node modules
  */
 export const getExecutionEnvironment = (): NodeJS.ProcessEnv => {
-    const env: NodeJS.ProcessEnv = { ...process.env };
+    const env: NodeJS.ProcessEnv = {};
+
+    // Copy non-APIFY variables
+    Object.keys(process.env).forEach((key) => {
+        if (!key.startsWith('APIFY_')) {
+            env[key] = process.env[key];
+        }
+    });
 
     // Add Python venv to PATH
     const currentPath = env.PATH || '';


### PR DESCRIPTION
## Summary

Reverts PR #8 which installed apify-cli globally and removed APIFY environment variable filtering.

### Changes
- Restores APIFY_ environment variable filtering in `getExecutionEnvironment()`
- Restores APIFY_ filtering in `initializePythonEnvironment()` venv creation
- Removes global apify-cli installation from Docker image
- Removes apify-cli references from README