### PR TITLE
docs: add global README and refactor Actor documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,110 @@
+# 🧪 Apify AI Sandbox
+
+A suite of Apify Actors providing secure, containerized environments for AI coding agents.
+
+[![Apify Actors](https://img.shields.io/badge/Apify-Actors-blue)](https://apify.com)
+[![Node.js 24](https://img.shields.io/badge/Node.js-24-green)](https://nodejs.org)
+[![Python 3](https://img.shields.io/badge/Python-3-blue)](https://python.org)
+
+## Overview
+
+This monorepo contains three Apify Actors designed for AI-powered coding workflows:
+
+| Actor | Description | Use Case |
+|-------|-------------|----------|
+| **[AI Sandbox](./sandbox)** | Core containerized environment with REST API, MCP server, and interactive shell | General AI agent development, sandboxed code execution |
+| **[Claude Code](./claude-code)** | One-click access to Anthropic's Claude Code | Instant Claude Code sessions on Apify |
+| **[OpenCode](./opencode)** | One-click access to open-source OpenCode | Free/open-source AI coding with multiple AI models support |
+
+## Architecture
+
+The **AI Sandbox** is the core Actor that provides the full execution environment:
+
+- Debian Trixie container with Node.js 24 and Python 3
+- RESTful filesystem API for file operations
+- MCP (Model Context Protocol) server for AI agent integration
+- Interactive browser-based terminal (ttyd)
+- Dependency management for npm and pip packages
+
+The **Claude Code** and **OpenCode** Actors are lightweight proxies that [metamorph](https://docs.apify.com/platform/actors/development/programming-interface/metamorph) into the AI Sandbox, automatically launching their respective CLI tools in the terminal.
+
+## Quick Start
+
+### Use on Apify Platform
+
+1. **AI Sandbox**: [Run on Apify](https://apify.com/apify/ai-sandbox) - Full sandbox with API access
+2. **Claude Code**: [Run on Apify](https://apify.com/apify/claude-code) - Auto-opens Claude Code CLI
+3. **OpenCode**: [Run on Apify](https://apify.com/apify/opencode) - Auto-opens OpenCode CLI
+
+### Connect to a Running Sandbox
+
+Once running, connect via:
+
+- **MCP Client**: `https://<RUN-ID>.runs.apify.net/mcp`
+- **REST API**: `POST /exec`, `GET/PUT/DELETE /fs/*`
+- **Interactive Shell**: `https://<RUN-ID>.runs.apify.net/shell/`
+
+## Features
+
+- **🔒 Secure Isolation**: Execute untrusted code safely in containerized environments
+- **🤖 AI Agent Ready**: MCP server with tools for file operations and code execution
+- **📦 Multi-Language**: JavaScript, TypeScript, Python, and shell command support
+- **🖥️ Interactive Shell**: Browser-based terminal for real-time debugging
+- **🔗 Actor Orchestration**: Agents can use the Apify token to run other Actors
+- **📂 Filesystem API**: RESTful endpoints for file upload, download, and management
+- **⚡ Auto-Shutdown**: Configurable idle timeout for cost efficiency
+
+## Repository Structure
+
+```
+├── sandbox/                 # Core AI Sandbox Actor
+│   ├── src/                 # Express server, MCP, file operations
+│   ├── artifacts/           # Configuration files (AGENTS.md, opencode.json)
+│   └── README.md            # Full API documentation
+│
+├── claude-code/             # Claude Code proxy Actor
+│   ├── src/main.ts          # Metamorph into sandbox
+│   └── README.md            # Claude Code specific docs
+│
+└── opencode/                # OpenCode proxy Actor
+    ├── src/main.ts          # Metamorph into sandbox
+    └── README.md            # OpenCode specific docs
+```
+
+## Development
+
+### Prerequisites
+
+- Node.js 24+
+- Docker (for local builds)
+
+### Build
+
+```bash
+# Build all Actors
+cd sandbox && npm install && npm run build
+cd ../claude-code && npm install && npm run build
+cd ../opencode && npm install && npm run build
+```
+
+### Deploy
+
+```bash
+# Deploy using Apify CLI
+cd sandbox && apify push
+cd ../claude-code && apify push
+cd ../opencode && apify push
+```
+
+## Documentation
+
+- [AI Sandbox README](./sandbox/README.md) - Full API reference and usage examples
+- [Claude Code README](./claude-code/README.md) - Claude Code integration details
+- [OpenCode README](./opencode/README.md) - OpenCode integration details
+
+## Links
+
+- [Apify Platform](https://apify.com)
+- [Model Context Protocol](https://modelcontextprotocol.io/)
+- [Claude Code](https://code.claude.com)
+- [OpenCode](https://opencode.ai)

--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -1,55 +1,41 @@
-# 🤖 Claude Code Sandbox
+# Claude Code
 
-**Run Claude Code on Apify - Effortlessly**
-
-This Actor provides a seamless way to execute [Claude Code](https://code.claude.com) agentic AI coding workflows on the Apify platform.
+Run [Claude Code](https://code.claude.com) on Apify infrastructure.
 
 ## 🔥 What is Claude Code?
 
-Claude Code is Anthropic's **agentic AI coding tool** that:
+Claude Code is Anthropic's terminal-based AI coding assistant that can:
 
-- Understands entire codebases without manual context
-- Performs real actions: edits files, runs commands, debugs code
-- Autonomously executes complex, multi-step coding tasks
-- Integrates with Git workflows, tests, and pull requests
+- Edit files and navigate codebases
+- Run shell commands and scripts
+- Execute multi-step coding tasks autonomously
+- Integrate with Git workflows
 
-## ⚡ How This Actor Works
+## ⚙️ How It Works
 
-**Just click Run - and you're in!**
-
-This Actor leverages the powerful [Apify AI Sandbox](https://apify.com/apify/ai-sandbox) to provide a complete development environment with Claude Code pre-configured and ready to use. When you start this Actor, the **Claude Code window automatically opens** in the Apify Actor run console view.
-
-The [Apify AI Sandbox](https://apify.com/apify/ai-sandbox) provides:
-
-- Full Node.js and Python environments
-- Pre-installed development tools
-- Secure containerized execution
-- Web-based terminal access
-- Claude Code and OpenCode CLI integration
+This Actor [metamorphs](https://docs.apify.com/platform/actors/development/programming-interface/metamorph) into the [AI Sandbox](https://apify.com/apify/ai-sandbox) and automatically launches Claude Code in the terminal.
 
 ## 🚀 Quick Start
 
-1. **Click "Start"** on this Actor
-2. **Claude Code opens automatically** in the console view
-3. Start coding with AI assistance immediately!
+1. Click **Start** on this Actor
+2. Claude Code opens in the console terminal
+3. Start coding
 
-Optional configuration:
+## 📦 Configuration
 
-- Customize initialization scripts
-- Set idle timeout preferences
-
-## 📦 Input Configuration
-
-- **initShellScript** - Custom bash setup script for installing packages or configuring the environment
-- **idleTimeoutSeconds** - Auto-shutdown after inactivity (default: 600s)
+| Input | Description | Default |
+|-------|-------------|---------|
+| `initShellScript` | Bash script to run before Claude Code starts | - |
+| `idleTimeoutSeconds` | Shutdown after inactivity | 600 |
 
 ## 🎯 Use Cases
 
-- Execute AI coding agents safely on Apify infrastructure
-- Run complex code generation workflows
-- Automate refactoring and debugging tasks
-- Integrate Claude Code into your Apify workflows
+- Run Claude Code without local installation
+- Execute AI coding tasks on Apify infrastructure
+- Integrate Claude Code into automation workflows
 
----
+## 🔗 Links
 
-**Built for developers who want to harness the power of agentic AI coding on Apify's scalable platform.**
+- [Claude Code](https://code.claude.com)
+- [Claude Code Documentation](https://code.claude.com/docs/en/overview)
+- [AI Sandbox](https://apify.com/apify/ai-sandbox)

--- a/opencode/README.md
+++ b/opencode/README.md
@@ -1,65 +1,40 @@
-# 🤖 OpenCode Sandbox
+# OpenCode
 
-**Run OpenCode on Apify - Effortlessly**
-
-This Actor provides a seamless way to execute [OpenCode](https://opencode.ai) agentic AI coding workflows on the Apify platform.
+Run [OpenCode](https://opencode.ai) on Apify infrastructure.
 
 ## 🔥 What is OpenCode?
 
-OpenCode is an **open-source AI coding agent** that:
+OpenCode is an open-source AI coding agent with:
 
-- Works as an intelligent coding assistant powered by various AI models
-- Supports **free built-in models** or easy connection to premium providers (Claude, GPT, Gemini, and 75+ others via Models.dev, including local models)
-- Available as terminal interface, desktop app (beta), and IDE extensions
-- **Privacy-first**: No storage of your code or context — ideal for sensitive projects
-- Trusted by **650,000+ monthly developers** with **70,000 GitHub stars**
+- Open-source and free to use
+- Support for multiple AI models (Claude, GPT, Gemini, local models)
+- Free built-in models available
 
-## ⚡ How This Actor Works
+## ⚙️ How It Works
 
-**Just click Run - and you're in!**
-
-This Actor leverages the powerful [Apify AI Sandbox](https://apify.com/apify/ai-sandbox) to provide a complete development environment with OpenCode pre-configured and ready to use. When you start this Actor, the **OpenCode window automatically opens** in the Apify Actor run console view.
-
-The [Apify AI Sandbox](https://apify.com/apify/ai-sandbox) provides:
-
-- Full Node.js and Python environments
-- Pre-installed development tools
-- Secure containerized execution
-- Web-based terminal access
-- OpenCode and Claude Code CLI integration
+This Actor [metamorphs](https://docs.apify.com/platform/actors/development/programming-interface/metamorph) into the [AI Sandbox](https://apify.com/apify/ai-sandbox) and automatically launches OpenCode in the terminal.
 
 ## 🚀 Quick Start
 
-1. **Click "Start"** on this Actor
-2. **OpenCode opens automatically** in the console view
-3. Start coding with AI assistance immediately!
+1. Click **Start** on this Actor
+2. OpenCode opens in the console terminal
+3. Start coding
 
-Optional configuration:
+## 📦 Configuration
 
-- Customize initialization scripts
-- Set idle timeout preferences
-
-## 📦 Input Configuration
-
-- **initShellScript** - Custom bash setup script for installing packages or configuring the environment
-- **idleTimeoutSeconds** - Auto-shutdown after inactivity (default: 600s)
+| Input | Description | Default |
+|-------|-------------|---------|
+| `initShellScript` | Bash script to run before OpenCode starts | - |
+| `idleTimeoutSeconds` | Shutdown after inactivity | 600 |
 
 ## 🎯 Use Cases
 
-- Execute AI coding agents safely on Apify infrastructure
-- Run complex code generation workflows with free or premium AI models
-- Automate refactoring and debugging tasks
-- Integrate OpenCode into your Apify workflows
-- Work with sensitive code in a privacy-first environment
+- Run OpenCode without local installation
+- Use free AI models for coding tasks
+- Integrate OpenCode into automation workflows
 
-## ⭐ Key Features
+## 🔗 Links
 
-- **Free to use** - Completely free with included models or connect your existing subscriptions
-- **Multi-session mode** - Run parallel agents on the same project
-- **LSP auto-loading** - Smart language support
-- **Shareable session links** - Collaborate or debug with others
-- **Access to Zen** - Handpicked, benchmarked models optimized specifically for coding agents
-
----
-
-**Built for developers who want to harness the power of open-source agentic AI coding on Apify's scalable platform.**
+- [OpenCode](https://opencode.ai)
+- [OpenCode GitHub](https://github.com/anomalyco/opencode)
+- [AI Sandbox](https://apify.com/apify/ai-sandbox)


### PR DESCRIPTION
## Summary

- Add comprehensive global README explaining the three-Actor monorepo architecture
- Refactor Claude Code and OpenCode READMEs: remove marketing fluff, unverifiable claims
- Verify and standardize all documentation links
- Consolidate architecture explanation with metamorph mechanism

## Files Changed
- README.md (new, 115 lines)
- claude-code/README.md (refactored)
- opencode/README.md (refactored)