### PR TITLE
feat: add skills support and enhance environment config

### DIFF
--- a/claude-code/.actor/actor.json
+++ b/claude-code/.actor/actor.json
@@ -15,6 +15,17 @@
     "type": "object",
     "schemaVersion": 1,
     "properties": {
+       "skills": {
+        "title": "Skills",
+        "type": "array",
+        "description": "List of skill packages to install for the AI coding agent. Skills are SKILLS.md files that provide specialized instructions. For more info see https://skills.sh/. Example: apify/agent-skills",
+        "editor": "stringList",
+        "items": {
+          "type": "string"
+        },
+        "default": ["apify/agent-skills"],
+        "prefill": ["apify/agent-skills"]
+      },
       "initShellScript": {
         "title": "Initialization Script",
         "type": "string",

--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -25,8 +25,13 @@ This Actor [metamorphs](https://docs.apify.com/platform/actors/development/progr
 
 | Input | Description | Default |
 |-------|-------------|---------|
+| `skills` | Skill packages to install (SKILLS.md files) | `["apify/agent-skills"]` |
 | `initShellScript` | Bash script to run before Claude Code starts | - |
 | `idleTimeoutSeconds` | Shutdown after inactivity | 600 |
+
+## 📚 Skills Support
+
+This Actor supports [SKILLS.md](https://skills.sh/) files - specialized instructions that enhance AI coding agent capabilities. Skills are installed automatically at startup.
 
 ## 🎯 Use Cases
 

--- a/opencode/.actor/actor.json
+++ b/opencode/.actor/actor.json
@@ -15,6 +15,17 @@
     "type": "object",
     "schemaVersion": 1,
     "properties": {
+       "skills": {
+        "title": "Skills",
+        "type": "array",
+        "description": "List of skill packages to install for the AI coding agent. Skills are SKILLS.md files that provide specialized instructions. For more info see https://skills.sh/. Example: apify/agent-skills",
+        "editor": "stringList",
+        "items": {
+          "type": "string"
+        },
+        "default": ["apify/agent-skills"],
+        "prefill": ["apify/agent-skills"]
+      },
       "initShellScript": {
         "title": "Initialization Script",
         "type": "string",

--- a/opencode/README.md
+++ b/opencode/README.md
@@ -24,8 +24,13 @@ This Actor [metamorphs](https://docs.apify.com/platform/actors/development/progr
 
 | Input | Description | Default |
 |-------|-------------|---------|
+| `skills` | Skill packages to install (SKILLS.md files) | `["apify/agent-skills"]` |
 | `initShellScript` | Bash script to run before OpenCode starts | - |
 | `idleTimeoutSeconds` | Shutdown after inactivity | 600 |
+
+## 📚 Skills Support
+
+This Actor supports [SKILLS.md](https://skills.sh/) files - specialized instructions that enhance AI coding agent capabilities. Skills are installed automatically at startup.
 
 ## 🎯 Use Cases
 

--- a/sandbox/.actor/actor.json
+++ b/sandbox/.actor/actor.json
@@ -16,6 +16,17 @@
         "type": "object",
         "schemaVersion": 1,
         "properties": {
+            "skills": {
+                "title": "Skills",
+                "type": "array",
+                "description": "List of skill packages to install for the AI coding agent. Skills are SKILLS.md files that provide specialized instructions. For more info see https://skills.sh/. Example: apify/agent-skills",
+                "editor": "stringList",
+                "items": {
+                    "type": "string"
+                },
+                "default": ["apify/agent-skills"],
+                "prefill": ["apify/agent-skills"]
+            },
             "nodeDependencies": {
                 "title": "Node.js Dependencies",
                 "type": "object",

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -108,6 +108,7 @@ RUN mkdir -p /sandbox/js-ts && chmod 755 /sandbox/js-ts && \
 
 # Copy AGENTS.md to sandbox for AI coding agents
 COPY --from=builder /build/artifacts/AGENTS.md /sandbox/AGENTS.md
+COPY --from=builder /build/artifacts/AGENTS.md /sandbox/CLAUDE.md
 
 # Capture baseline package state for migration persistence
 RUN mkdir -p /app && \
@@ -141,6 +142,15 @@ RUN npm install --production
 
 # Add local bin to PATH for CLI tools (Claude at ~/.local/bin, OpenCode at ~/.opencode/bin)
 ENV PATH="/root/.local/bin:/root/.opencode/bin:$PATH"
+
+# Set IS_SANDBOX environment variable globally
+ENV IS_SANDBOX=1
+
+# Set Claude Code max output tokens to 64000
+ENV CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000
+
+# Add bash alias for claude to skip permissions by default
+RUN echo 'alias claude="claude --dangerously-skip-permissions"' >> /root/.bashrc
 
 # Capture tool versions at build time for fast shell startup
 COPY scripts/capture-versions.sh /tmp/capture-versions.sh

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -374,6 +374,15 @@ apt-get update && apt-get install -y curl
 mkdir -p /sandbox/custom-data && chmod 755 /sandbox/custom-data
 ```
 
+### Skills support (SKILLS.md)
+
+Install skill packages that provide specialized instructions for AI coding agents. Skills are SKILLS.md files that enhance agent capabilities.
+
+- Specify skills via the "Skills" input (array of package names)
+- Example: `["apify/agent-skills"]`
+- Skills are installed globally during Actor startup
+- For more info see [skills.sh](https://skills.sh/)
+
 ## Learn more
 
 - [Apify Actor documentation](https://docs.apify.com/platform/actors)

--- a/sandbox/artifacts/AGENTS.md
+++ b/sandbox/artifacts/AGENTS.md
@@ -111,6 +111,31 @@ Pre-configured and ready:
     - **`APIFY_TOKEN`** - API authentication token
     - **`ACTOR_DEFAULT_DATASET_ID`** - Default dataset ID for this Actor
     - **`ACTOR_DEFAULT_KEY_VALUE_STORE_ID`** - Default key-value store ID for this Actor
+
+### 🚨 CRITICAL: APIFY_TOKEN Already Available in Environment
+
+The **`APIFY_TOKEN`** environment variable is **already set and ready to use** in your current environment. You can freely use it in any script without additional setup:
+
+**Python:**
+```python
+import os
+token = os.environ['APIFY_TOKEN']  # ✅ Already available - use it directly!
+client = ApifyClient(token)
+```
+
+**JavaScript/TypeScript:**
+```javascript
+const token = process.env.APIFY_TOKEN;  // ✅ Already available - use it directly!
+const client = new ApifyClient({ token });
+```
+
+**Bash/Shell:**
+```bash
+echo $APIFY_TOKEN  # ✅ Already available - use it directly!
+mcpc --header "Authorization: Bearer $APIFY_TOKEN" https://mcp.apify.com tools-list --json
+```
+
+**No setup required:** The token is pre-configured. Just reference it and start building!
 - **apify-client** pre-installed:
     - Python: `/sandbox/py/venv` (activated automatically for Python execution)
     - JavaScript/TypeScript: `/sandbox/js-ts/node_modules` (available for JS/TS execution)

--- a/sandbox/src/main.ts
+++ b/sandbox/src/main.ts
@@ -77,12 +77,15 @@ if (restoredFromMigration) {
     log.info('Skipping dependency installation (already restored from migration)');
     setupResult = {
         success: true,
+        skillsSetup: { installed: [], failed: [] },
         nodeSetup: { installed: [], failed: [] },
         pythonSetup: { installed: [], failed: [] },
+        errors: [],
     };
 } else {
     log.info('Setting up execution environment...');
     setupResult = await setupExecutionEnvironment({
+        skills: input?.skills,
         nodeDependencies: input?.nodeDependencies,
         pythonRequirementsTxt: input?.pythonRequirementsTxt,
     });
@@ -90,13 +93,15 @@ if (restoredFromMigration) {
 
 if (!setupResult.success) {
     log.warning('Some dependencies failed to install', {
+        skillsInstalled: setupResult.skillsSetup.installed,
+        skillsFailed: setupResult.skillsSetup.failed,
         nodeInstalled: setupResult.nodeSetup.installed,
         nodeFailed: setupResult.nodeSetup.failed,
         pythonInstalled: setupResult.pythonSetup.installed,
         pythonFailed: setupResult.pythonSetup.failed,
     });
 } else {
-    log.info('All dependencies installed successfully');
+    log.info('All dependencies and skills installed successfully');
 }
 
 // Execute init script if provided and not empty
@@ -789,7 +794,7 @@ app.all('/shell*', (req, res) => {
     let path = req.url.replace(/^\/shell/, '') || '/';
     // Ensure path starts with / (handle query strings like ?arg=...)
     if (path.startsWith('?')) {
-        path = '/' + path;
+        path = `/${  path}`;
     }
     const options = {
         hostname: '127.0.0.1',
@@ -834,7 +839,7 @@ app.all('/browser*', (req, res) => {
     // Rewrite path: /browser/foo → /foo
     req.url = req.url.replace(/^\/browser/, '') || '/';
     if (req.url.startsWith('?')) {
-        req.url = '/' + req.url;
+        req.url = `/${  req.url}`;
     }
 
     log.info('Proxying browser HTTP request', { url: req.url });

--- a/sandbox/src/types.ts
+++ b/sandbox/src/types.ts
@@ -4,6 +4,14 @@
 
 export interface ActorInput {
     /**
+     * Skill packages to install for the AI coding agent
+     * Skills are SKILL.md files that provide specialized instructions
+     * Format: array of skill package names or URLs
+     * Example: ["apify/agent-skills"]
+     */
+    skills?: string[];
+
+    /**
      * Node.js dependencies object for JavaScript and TypeScript code execution
      * Format: { "package-name": "version", ... }
      * Example: { "zod": "^3.0", "axios": "latest" }


### PR DESCRIPTION
## Summary
This PR introduces support for installing AI skills via `SKILLS.md` files and enhances the sandbox environment configuration.

### Changes
- **Skills Support:**
  - Added `skills` input field to `sandbox`, `claude-code`, and `opencode` Actors.
  - Implemented `installSkills` function to install skills using `npx skills`.
  - Updated READMEs with documentation for Skills support.
- **Environment Configuration:**
  - Added `IS_SANDBOX=1` global environment variable in Dockerfile.
  - Set `CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000` in Dockerfile.
  - Added `alias claude="claude --dangerously-skip-permissions"` to `.bashrc`.
- **Documentation:**
  - Updated `AGENTS.md` to highlight `APIFY_TOKEN` availability.