### PR TITLE
fix: prevent state loss across multiple abort+resurrect cycles

### DIFF
--- a/sandbox/src/main.ts
+++ b/sandbox/src/main.ts
@@ -143,6 +143,10 @@ if (!isLocalMode) {
 }
 
 // Initialize persistence system (create startup marker for tracking changes)
+// Only needed on fresh starts — after migration restore, the marker is already
+// set with the correct timestamp by restoreStartupMarkerTimestamp() inside
+// restoreMigrationState(). This ensures `find -newer marker` catches both
+// restored files (which have their original mtimes from tar) and any new files.
 if (!isLocalMode && !restoredFromMigration) {
     try {
         initializePersistence();


### PR DESCRIPTION
## Summary
- Fixes migration persistence losing all filesystem state after the second abort+resurrect cycle
- Root cause was two interacting bugs in how the startup marker timestamp interacts with `find -newer` and tar's mtime preservation

## The Bugs

**Bug 1 — Missing startup marker after restore**: `initializePersistence()` was guarded by `!restoredFromMigration`, so after a successful restore the marker was never recreated. The next `persistState` save found no marker → returned empty file list → overwrote the good snapshot with nothing.

**Bug 2 — `find -newer` timestamp mismatch**: `tar -xzf` preserves original file mtimes. A freshly created marker (`mtime = now`) meant `find -newer marker` missed all restored files (they appeared "older"). The next save produced an empty tarball even with the marker present.

## The Fix

After successful restore, set the marker's mtime back to the original `startupTimestamp` from the manifest via `utimesSync`. This ensures `find -newer` catches both restored files AND any new files created after restoration. Fresh starts continue creating a new marker as before.

## Testing

Verified on Apify platform with a full **create state → abort → resurrect → create more state → abort → resurrect → verify** cycle. All files, directories, and pip packages survived both cycles.