### PR TITLE
Add support for user-supplied environment variables in sandbox

### DIFF
--- a/claude-code/.actor/actor.json
+++ b/claude-code/.actor/actor.json
@@ -33,6 +33,13 @@
         "editor": "textarea",
         "prefill": "apt-get update\n# apt-get install -y curl"
       },
+      "envVars": {
+        "title": "Environment Variables",
+        "type": "string",
+        "description": "Secret environment variables exposed to the sandbox shell, init script, and code execution. Encrypted at rest by Apify and decrypted only at runtime.\n\nAccepts either format:\n- **KEY=VALUE per line** (dotenv-style):\n  ```\n  OPENAI_API_KEY=sk-...\n  MY_VAR=hello\n  ```\n- **JSON object**:\n  ```\n  {\"OPENAI_API_KEY\": \"sk-...\", \"MY_VAR\": \"hello\"}\n  ```",
+        "editor": "textarea",
+        "isSecret": true
+      },
        "idleTimeoutSeconds": {
          "title": "Idle Timeout Seconds",
          "type": "integer",

--- a/openclaw/.actor/actor.json
+++ b/openclaw/.actor/actor.json
@@ -33,6 +33,13 @@
         "editor": "textarea",
         "prefill": "apt-get update\n# apt-get install -y curl"
       },
+      "envVars": {
+        "title": "Environment Variables",
+        "type": "string",
+        "description": "Secret environment variables exposed to the sandbox shell, init script, and code execution. Encrypted at rest by Apify and decrypted only at runtime.\n\nAccepts either format:\n- **KEY=VALUE per line** (dotenv-style):\n  ```\n  OPENAI_API_KEY=sk-...\n  MY_VAR=hello\n  ```\n- **JSON object**:\n  ```\n  {\"OPENAI_API_KEY\": \"sk-...\", \"MY_VAR\": \"hello\"}\n  ```",
+        "editor": "textarea",
+        "isSecret": true
+      },
       "idleTimeoutSeconds": {
         "title": "Idle Timeout Seconds",
         "type": "integer",

--- a/opencode/.actor/actor.json
+++ b/opencode/.actor/actor.json
@@ -33,6 +33,13 @@
         "editor": "textarea",
         "prefill": "apt-get update\n# apt-get install -y curl"
       },
+      "envVars": {
+        "title": "Environment Variables",
+        "type": "string",
+        "description": "Secret environment variables exposed to the sandbox shell, init script, and code execution. Encrypted at rest by Apify and decrypted only at runtime.\n\nAccepts either format:\n- **KEY=VALUE per line** (dotenv-style):\n  ```\n  OPENAI_API_KEY=sk-...\n  MY_VAR=hello\n  ```\n- **JSON object**:\n  ```\n  {\"OPENAI_API_KEY\": \"sk-...\", \"MY_VAR\": \"hello\"}\n  ```",
+        "editor": "textarea",
+        "isSecret": true
+      },
       "idleTimeoutSeconds": {
         "title": "Idle Timeout Seconds",
         "type": "integer",

--- a/sandbox/.actor/actor.json
+++ b/sandbox/.actor/actor.json
@@ -48,6 +48,13 @@
                 "editor": "textarea",
                 "prefill": "apt-get update\n# apt-get install -y curl\n# mkdir /sandbox/data"
             },
+            "envVars": {
+                "title": "Environment Variables",
+                "type": "string",
+                "description": "Secret environment variables exposed to the sandbox shell, init script, and code execution. Encrypted at rest by Apify and decrypted only at runtime.\n\nAccepts either format:\n- **KEY=VALUE per line** (dotenv-style):\n  ```\n  OPENAI_API_KEY=sk-...\n  MY_VAR=hello\n  ```\n- **JSON object**:\n  ```\n  {\"OPENAI_API_KEY\": \"sk-...\", \"MY_VAR\": \"hello\"}\n  ```",
+                "editor": "textarea",
+                "isSecret": true
+            },
             "idleTimeoutSeconds": {
                 "title": "Idle Timeout Seconds",
                 "type": "integer",

--- a/sandbox/src/env-vars.ts
+++ b/sandbox/src/env-vars.ts
@@ -1,0 +1,84 @@
+import { log } from 'apify';
+
+const VALID_KEY = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+const parseJsonObject = (raw: string): Record<string, string> => {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch (error) {
+        const err = error as Error;
+        log.warning('envVars: failed to parse JSON input, ignoring', { error: err.message });
+        return {};
+    }
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        log.warning('envVars: JSON must be a flat object of string keys and string values');
+        return {};
+    }
+
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+        if (!VALID_KEY.test(key)) {
+            log.warning('envVars: skipping invalid key', { key });
+            continue;
+        }
+        if (value === null || value === undefined) continue;
+        if (typeof value === 'object') {
+            log.warning('envVars: skipping non-scalar value', { key });
+            continue;
+        }
+        out[key] = String(value);
+    }
+    return out;
+};
+
+const stripQuotes = (value: string): string => {
+    if (value.length < 2) return value;
+    const first = value[0];
+    const last = value[value.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+        return value.slice(1, -1);
+    }
+    return value;
+};
+
+const parseDotenv = (raw: string): Record<string, string> => {
+    const out: Record<string, string> = {};
+    for (const rawLine of raw.split(/\r?\n/)) {
+        const line = rawLine.trim();
+        if (!line || line.startsWith('#')) continue;
+
+        const stripped = line.startsWith('export ') ? line.slice('export '.length).trimStart() : line;
+        const eq = stripped.indexOf('=');
+        if (eq <= 0) {
+            log.warning('envVars: skipping malformed line (expected KEY=VALUE)', { line: rawLine });
+            continue;
+        }
+
+        const key = stripped.slice(0, eq).trim();
+        const value = stripQuotes(stripped.slice(eq + 1).trim());
+
+        if (!VALID_KEY.test(key)) {
+            log.warning('envVars: skipping invalid key', { key });
+            continue;
+        }
+        out[key] = value;
+    }
+    return out;
+};
+
+/**
+ * Parse user-supplied envVars input. Accepts either:
+ *  - a JSON object (input starts with `{`), or
+ *  - dotenv-style `KEY=VALUE` lines (`#` comments and optional `export ` prefix allowed).
+ *
+ * Invalid keys, non-scalar JSON values, or malformed lines are skipped with a warning;
+ * the actor still starts so a single bad entry doesn't break the run.
+ */
+export const parseEnvVars = (raw: string | undefined | null): Record<string, string> => {
+    if (!raw) return {};
+    const trimmed = raw.trim();
+    if (!trimmed) return {};
+    return trimmed.startsWith('{') ? parseJsonObject(trimmed) : parseDotenv(trimmed);
+};

--- a/sandbox/src/environment.ts
+++ b/sandbox/src/environment.ts
@@ -374,6 +374,25 @@ export const setupExecutionEnvironment = async (input: {
 };
 
 /**
+ * User-supplied environment variables (parsed from the secret `envVars` input).
+ * Held in module scope so all execution paths share the same source of truth.
+ */
+let userEnvVars: Record<string, string> = {};
+
+/**
+ * Set the user-supplied environment variables. Called once during startup
+ * after parsing the actor input.
+ */
+export const setUserEnvVars = (vars: Record<string, string>): void => {
+    userEnvVars = { ...vars };
+};
+
+/**
+ * Get the parsed user-supplied environment variables (read-only copy).
+ */
+export const getUserEnvVars = (): Record<string, string> => ({ ...userEnvVars });
+
+/**
  * Get environment variables for code execution
  * Returns environment with paths to Python venv and Node modules
  */
@@ -384,6 +403,10 @@ export const getExecutionEnvironment = (): NodeJS.ProcessEnv => {
     Object.keys(process.env).forEach((key) => {
         env[key] = process.env[key];
     });
+
+    // Layer in user-supplied vars before our infra paths so the sandbox
+    // PATH/NODE_PATH/VIRTUAL_ENV/PYTHONHOME below always win.
+    Object.assign(env, userEnvVars);
 
     // Add Python venv to PATH
     const currentPath = env.PATH || '';

--- a/sandbox/src/main.ts
+++ b/sandbox/src/main.ts
@@ -12,7 +12,8 @@ import express from 'express';
 import httpProxy from 'http-proxy';
 
 import { SANDBOX_DIR } from './consts.js';
-import { executeInitScript, setupExecutionEnvironment } from './environment.js';
+import { parseEnvVars } from './env-vars.js';
+import { executeInitScript, setupExecutionEnvironment, setUserEnvVars } from './environment.js';
 import { createMcpServer } from './mcp.js';
 import {
     appendFile,
@@ -61,11 +62,18 @@ const serverUrl = process.env.ACTOR_WEB_SERVER_URL || `http://localhost:${port}`
 
 // Retrieve Actor input
 const input = await Actor.getInput<ActorInput>();
+
+// Parse and register user-supplied environment variables. Apify decrypts the
+// secret input at runtime; we never log values, only key names.
+const userEnvVars = parseEnvVars(input?.envVars);
+setUserEnvVars(userEnvVars);
+
 log.info('Actor input retrieved', {
     mode: isLocalMode ? 'local' : 'production',
     hasNodeDependencies: !!input?.nodeDependencies && Object.keys(input.nodeDependencies).length > 0,
     hasPythonRequirements: !!input?.pythonRequirementsTxt?.trim().length,
     hasInitScript: !!input?.initShellScript?.trim().length,
+    envVarKeys: Object.keys(userEnvVars),
 });
 
 // Check for migration state and restore if available
@@ -850,7 +858,7 @@ const spawnTtyd = () => {
     const ttyd = spawn('ttyd', ['-p', shellPort.toString(), '-a', '-W', 'bash', '--rcfile', '/app/sandbox_bashrc'], {
         stdio: 'ignore',
         cwd: SANDBOX_DIR,
-        env: process.env,
+        env: { ...process.env, ...userEnvVars },
     });
 
     ttyd.on('error', (err) => {

--- a/sandbox/src/types.ts
+++ b/sandbox/src/types.ts
@@ -42,6 +42,13 @@ export interface ActorInput {
     initShellScript?: string;
 
     /**
+     * Secret environment variables exposed to the sandbox shell, init script,
+     * and code execution. Accepts either dotenv-style KEY=VALUE lines or a JSON
+     * object. Encrypted at rest by Apify (isSecret in input schema).
+     */
+    envVars?: string;
+
+    /**
      * Graceful shutdown timeout in seconds if no activity is detected.
      * Activity includes HTTP requests and shell interaction.
      * @default 600 (10 minutes)


### PR DESCRIPTION
## Summary
This PR adds support for passing secret environment variables to the sandbox through a new `envVars` actor input. Users can supply variables in either dotenv-style (`KEY=VALUE` lines) or JSON object format, which are then made available to the shell, init script, and code execution environments.

## Key Changes
- **New `env-vars.ts` module**: Implements parsing logic for both dotenv and JSON formats with validation
  - Validates environment variable names against the pattern `^[A-Za-z_][A-Za-z0-9_]*$`
  - Handles comments and optional `export` prefix in dotenv format
  - Strips surrounding quotes from dotenv values
  - Logs warnings for invalid entries without breaking execution
  
- **Environment variable management in `environment.ts`**:
  - Added module-scoped `userEnvVars` to maintain a single source of truth
  - Exported `setUserEnvVars()` to register parsed variables during startup
  - Exported `getUserEnvVars()` to retrieve a read-only copy
  - Modified `getExecutionEnvironment()` to layer user variables before infrastructure paths (ensuring sandbox paths always take precedence)

- **Integration in `main.ts`**:
  - Parse `envVars` input immediately after retrieving actor input
  - Register parsed variables via `setUserEnvVars()`
  - Log environment variable keys (never values) in startup info
  - Pass user variables to ttyd shell spawning

- **Actor input schema updates** (all four actors):
  - Added `envVars` input field as a secret textarea
  - Documented both supported formats with examples
  - Marked as `isSecret: true` for Apify encryption at rest

## Implementation Details
- User variables are layered into the execution environment *before* infrastructure paths (Python venv, Node modules), ensuring sandbox-critical paths always take precedence
- Invalid keys, non-scalar JSON values, and malformed lines are skipped with warnings rather than failing the entire run
- Secret values are never logged; only key names are included in startup logs
- The implementation uses a module-scoped variable pattern to ensure all execution paths share the same parsed variables

https://claude.ai/code/session_012kk4CREZeAVvXT3pQDyDTP