### PR TITLE
Conditionally skip test script message in CI environment

### DIFF
--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -45,7 +45,7 @@
         "lint:fix": "eslint --fix",
         "format": "prettier --write .",
         "format:check": "prettier --check .",
-        "test": "echo \"ℹ️  No unit tests available. For E2E platform tests, run: npm run test:e2e\" && exit 0",
+        "test": "[ -n \"$APIFY_IS_AT_HOME\" ] || echo \"ℹ️  No unit tests available. For E2E platform tests, run: npm run test:e2e\"",
         "test:e2e": "tsx tests/e2e.ts"
     },
     "author": "It's not you it's me",


### PR DESCRIPTION
## Summary
Modified the test script in package.json to conditionally skip the informational message when running in the Apify platform environment.

## Key Changes
- Updated the `test` script to check for the `APIFY_IS_AT_HOME` environment variable
- When the variable is set (indicating execution on Apify platform), the script exits silently without printing the message
- When running locally, the informational message about E2E tests is still displayed
- Removed the `exit 0` to allow the script to exit with the appropriate status code

## Implementation Details
The script now uses a bash conditional `[ -n "$APIFY_IS_AT_HOME" ]` to detect the Apify platform environment. This prevents unnecessary output during platform test runs while maintaining helpful guidance for local development.

https://claude.ai/code/session_01MnVQwYo5joA26DZ5ozA42D