### PR TITLE
Fix npm install issues with apify-cli and apify-client

### DIFF
--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -54,7 +54,8 @@ RUN apt-get update && apt-get install -y \
 RUN npm install -g tsx
 
 # Install Apify CLI globally
-RUN npm install -g apify-cli
+# --ignore-scripts works around apify-client's `only-allow pnpm` preinstall hook
+RUN npm install -g --ignore-scripts apify-cli
 
 # Install Apify MCP CLI globally (package: @apify/mcpc, binary: mcpc)
 # Using beta for named connection support (mcpc connect ... @session)
@@ -80,7 +81,7 @@ RUN mkdir -p /sandbox/py && chmod 755 /sandbox/py && \
 RUN mkdir -p /sandbox/js-ts && chmod 755 /sandbox/js-ts && \
     cd /sandbox/js-ts && \
     echo '{"name":"apify-sandbox-js-ts","version":"1.0.0","description":"Sandbox for JS/TS code execution","type":"module","dependencies":{"apify-client":"*"}}' > package.json && \
-    npm install && \
+    npm install --ignore-scripts && \
     echo "apify-client pre-installed in Node.js environment"
 
 # Copy AGENTS.md to sandbox for AI coding agents


### PR DESCRIPTION
## Summary
This PR resolves npm installation failures caused by apify-client's `only-allow pnpm` preinstall hook by adding the `--ignore-scripts` flag to npm install commands in the Dockerfile.

## Key Changes
- Added `--ignore-scripts` flag to the global `apify-cli` installation to bypass the preinstall hook that enforces pnpm usage
- Added `--ignore-scripts` flag to the `apify-client` installation in the Node.js/TypeScript sandbox environment setup
- Added explanatory comment documenting the workaround for the preinstall hook issue

## Implementation Details
The apify-client package includes a preinstall script that enforces the use of pnpm as the package manager. Since the Docker environment uses npm, this script would fail during installation. By using the `--ignore-scripts` flag, we skip the execution of lifecycle scripts (preinstall, postinstall, etc.) while still installing the package and its dependencies successfully.

This change ensures reliable Docker image builds without requiring a switch to pnpm or other workarounds.

https://claude.ai/code/session_01QnK8F3AzuEiyEGFMsMwnX7