### PR TITLE
Add flexible Node.js dependencies parser supporting CLI and JSON formats

### DIFF
--- a/sandbox/.actor/actor.json
+++ b/sandbox/.actor/actor.json
@@ -29,10 +29,10 @@
             },
             "nodeDependencies": {
                 "title": "Node.js dependencies",
-                "type": "object",
-                "description": "npm package.json dependencies object for JavaScript and TypeScript code execution (/sandbox/js-ts). Paste your dependencies in npm format. Example: {\"zod\": \"^3.0\", \"axios\": \"latest\"}",
-                "editor": "json",
-                "prefill": {}
+                "type": "string",
+                "description": "npm packages to install for JavaScript and TypeScript code execution (/sandbox/js-ts).\n\nAccepts either format:\n- **One `package@version` per line** (npm CLI style):\n  ```\n  zod@^3.0\n  axios@latest\n  lodash\n  ```\n  Lines without `@version` default to `latest`. Blank lines and `#` comments are ignored. Scoped packages like `@types/node@^20` are supported.\n- **JSON object** (package.json `dependencies` style):\n  ```\n  {\"zod\": \"^3.0\", \"axios\": \"latest\"}\n  ```",
+                "editor": "textarea",
+                "prefill": ""
             },
             "pythonRequirementsTxt": {
                 "title": "Python requirements",

--- a/sandbox/.actor/actor.json
+++ b/sandbox/.actor/actor.json
@@ -32,7 +32,7 @@
                 "type": "string",
                 "description": "npm packages to install for JavaScript and TypeScript code execution (/sandbox/js-ts).\n\nAccepts either format:\n- **One `package@version` per line** (npm CLI style):\n  ```\n  zod@^3.0\n  axios@latest\n  lodash\n  ```\n  Lines without `@version` default to `latest`. Blank lines and `#` comments are ignored. Scoped packages like `@types/node@^20` are supported.\n- **JSON object** (package.json `dependencies` style):\n  ```\n  {\"zod\": \"^3.0\", \"axios\": \"latest\"}\n  ```",
                 "editor": "textarea",
-                "prefill": ""
+                "prefill": "# One package@version per line. Omit @version for latest.\n# zod@^3.0\n# axios@latest\n# @types/node@^20"
             },
             "pythonRequirementsTxt": {
                 "title": "Python requirements",

--- a/sandbox/AGENTS.md
+++ b/sandbox/AGENTS.md
@@ -34,7 +34,8 @@ tsc -p tsconfig.build.json     # Full build with output
 # Building is slow and unnecessary for development/testing - tsx runs TypeScript directly
 
 # Testing
-npm test                       # Run tests (placeholder - no unit tests)
+npm test                       # Run unit + e2e (full suite, local dev)
+npm run test:unit              # Run unit tests only (tests/unit/*.test.ts via node --test + tsx)
 npm run test:e2e               # Run E2E platform tests (deploys to Apify)
 
 # Apify CLI
@@ -45,11 +46,20 @@ apify push                     # Deploy to Apify platform
 
 ### Running a Single Test
 
-Currently there are no unit tests. The E2E test suite deploys to Apify platform and tests all endpoints:
+Unit tests live in `tests/unit/*.test.ts` and run via Node's built-in test runner with `tsx` as the loader (no extra deps). The Dockerfile runs `npm run test:unit` after `npm run build`, so a regression in pure-logic code fails the build.
 
 ```bash
+# Run all unit tests
+npm run test:unit
+
+# Run a single unit test file
+node --import tsx --test tests/unit/node-deps.test.ts
+
 # Run E2E platform tests (deploys Actor, runs tests, cleans up)
 npm run test:e2e
+
+# Run the full suite (unit + e2e)
+npm test
 ```
 
 ## Code Style Guidelines
@@ -120,7 +130,32 @@ app.post('/endpoint', async (req: Request, res: Response) => {
 ### Testing
 
 - Tests in `tests/` directory with `.ts` extension, executable with `tsx`
-- E2E platform test suite: `tests/e2e.ts` (deploys to Apify, runs 47 endpoint tests, cleans up)
+- **Unit tests:** files matching `tests/unit/*.test.ts`, run via `npm run test:unit` (Node's built-in `node:test` runner via `node --import tsx`, no extra deps). Also run during the Docker build.
+- **E2E platform test suite:** `tests/e2e.ts` (deploys to Apify, runs endpoint tests, cleans up)
+
+**When to add a unit test:** any new pure function (parser, validator, transform) — anything you can exercise without spinning up the Actor, Express, or external services. Prefer unit tests for I/O-free logic; reserve E2E for endpoint behavior. Bug fixes in pure logic should land with a regression test.
+
+**How to add a unit test:**
+
+1. Create `tests/unit/<module>.test.ts` next to existing test files.
+2. Use `node:test` (`describe`/`it`) and `node:assert/strict`:
+
+    ```typescript
+    /* eslint-disable @typescript-eslint/no-floating-promises -- node:test's describe/it return promises by design */
+    import assert from 'node:assert/strict';
+    import { describe, it } from 'node:test';
+
+    import { myFn } from '../../src/my-module.js'; // .js extension required
+
+    describe('myFn', () => {
+        it('does the thing', () => {
+            assert.deepEqual(myFn('input'), { ok: true });
+        });
+    });
+    ```
+
+3. Run `npm run test:unit` to verify. Test files are picked up by the `tests/unit/*.test.ts` glob — no further wiring needed.
+4. Keep tests pure: no network, no filesystem writes, no `apify`/`Actor.init()`. If you need fixtures, inline them in the test file.
 
 ## What are Apify Actors?
 

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -371,9 +371,16 @@ The sandbox provides isolated execution environments for different code language
 
 Specify dependencies to install via Actor input:
 
-- **Node.js Dependencies**: npm packages for JS/TS code execution in native npm format
-    - Input as a JSON object: `{"package-name": "version", ...}`
-    - Example: `{"zod": "^3.0", "axios": "latest", "lodash": "4.17.21"}`
+- **Node.js Dependencies**: npm packages for JS/TS code execution. Accepts either format:
+    - **One `package@version` per line** (npm CLI style):
+        ```
+        zod@^3.0
+        axios@latest
+        lodash
+        @types/node@^20
+        ```
+        Lines without `@version` default to `latest`. Blank lines and `#` comments are ignored.
+    - **JSON object** (package.json `dependencies` style): `{"zod": "^3.0", "axios": "latest"}`
 - **Python Requirements**: pip packages for Python code execution in requirements.txt format
     - Input as multi-line text: one package per line with optional version specifiers
     - Example:

--- a/sandbox/src/main.ts
+++ b/sandbox/src/main.ts
@@ -15,6 +15,7 @@ import { SANDBOX_DIR } from './consts.js';
 import { parseEnvVars } from './env-vars.js';
 import { executeInitScript, setupExecutionEnvironment, setUserEnvVars } from './environment.js';
 import { createMcpServer } from './mcp.js';
+import { parseNodeDependencies } from './node-deps.js';
 import {
     appendFile,
     createDirectory,
@@ -68,9 +69,11 @@ const input = await Actor.getInput<ActorInput>();
 const userEnvVars = parseEnvVars(input?.envVars);
 setUserEnvVars(userEnvVars);
 
+const nodeDependencies = parseNodeDependencies(input?.nodeDependencies);
+
 log.info('Actor input retrieved', {
     mode: isLocalMode ? 'local' : 'production',
-    hasNodeDependencies: !!input?.nodeDependencies && Object.keys(input.nodeDependencies).length > 0,
+    hasNodeDependencies: Object.keys(nodeDependencies).length > 0,
     hasPythonRequirements: !!input?.pythonRequirementsTxt?.trim().length,
     hasInitScript: !!input?.initShellScript?.trim().length,
     envVarKeys: Object.keys(userEnvVars),
@@ -102,7 +105,7 @@ if (restoredFromMigration) {
     log.info('Setting up execution environment...');
     setupResult = await setupExecutionEnvironment({
         skills: input?.skills,
-        nodeDependencies: input?.nodeDependencies,
+        nodeDependencies,
         pythonRequirementsTxt: input?.pythonRequirementsTxt,
     });
 }

--- a/sandbox/src/node-deps.ts
+++ b/sandbox/src/node-deps.ts
@@ -1,0 +1,85 @@
+import { log } from 'apify';
+
+const parseJsonObject = (raw: string): Record<string, string> => {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch (error) {
+        const err = error as Error;
+        log.warning('nodeDependencies: failed to parse JSON input, ignoring', { error: err.message });
+        return {};
+    }
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        log.warning('nodeDependencies: JSON must be a flat object of package names to version strings');
+        return {};
+    }
+
+    const out: Record<string, string> = {};
+    for (const [name, value] of Object.entries(parsed as Record<string, unknown>)) {
+        const pkg = name.trim();
+        if (!pkg) continue;
+        if (value === null || value === undefined || value === '') {
+            out[pkg] = 'latest';
+            continue;
+        }
+        if (typeof value !== 'string' && typeof value !== 'number') {
+            log.warning('nodeDependencies: skipping non-string version', { package: pkg });
+            continue;
+        }
+        out[pkg] = String(value);
+    }
+    return out;
+};
+
+/**
+ * Split a `package@version` line on the version separator. Returns `[name, version]`.
+ *
+ * Handles scoped packages (`@scope/name@version`) by splitting on the last `@`,
+ * not the first. A bare `package` (no `@version`) returns `version = 'latest'`.
+ */
+const splitSpec = (spec: string): [string, string] | null => {
+    const trimmed = spec.trim();
+    if (!trimmed) return null;
+
+    const isScoped = trimmed.startsWith('@');
+    const versionAt = isScoped ? trimmed.indexOf('@', 1) : trimmed.indexOf('@');
+
+    if (versionAt < 0) return [trimmed, 'latest'];
+
+    const name = trimmed.slice(0, versionAt).trim();
+    const version = trimmed.slice(versionAt + 1).trim();
+    if (!name) return null;
+    return [name, version || 'latest'];
+};
+
+const parseLines = (raw: string): Record<string, string> => {
+    const out: Record<string, string> = {};
+    for (const rawLine of raw.split(/\r?\n/)) {
+        const line = rawLine.trim();
+        if (!line || line.startsWith('#')) continue;
+
+        const split = splitSpec(line);
+        if (!split) {
+            log.warning('nodeDependencies: skipping malformed line', { line: rawLine });
+            continue;
+        }
+        out[split[0]] = split[1];
+    }
+    return out;
+};
+
+/**
+ * Parse the user-supplied `nodeDependencies` input. Accepts either:
+ *  - npm CLI-style lines: one `package@version` per line (`#` comments ignored,
+ *    missing `@version` defaults to `latest`, scoped packages supported), or
+ *  - a JSON object (input starts with `{`): `{ "package-name": "version", ... }`.
+ *
+ * Returns a `{ name: version }` object suitable for `installNodeLibraries`.
+ */
+export const parseNodeDependencies = (raw: string | undefined | null): Record<string, string> => {
+    if (!raw) return {};
+    const trimmed = raw.trim();
+    if (!trimmed) return {};
+    return trimmed.startsWith('{') ? parseJsonObject(trimmed) : parseLines(trimmed);
+};

--- a/sandbox/src/node-deps.ts
+++ b/sandbox/src/node-deps.ts
@@ -1,5 +1,10 @@
 import { log } from 'apify';
 
+/**
+ * Parse a `{ "package": "version" }` object. Coerces numeric versions to
+ * strings and null/empty values to `latest`; malformed JSON degrades to `{}`
+ * with a warning so a single bad character does not abort the run.
+ */
 const parseJsonObject = (raw: string): Record<string, string> => {
     let parsed: unknown;
     try {

--- a/sandbox/src/types.ts
+++ b/sandbox/src/types.ts
@@ -22,11 +22,11 @@ export interface ActorInput {
     skills?: string[];
 
     /**
-     * Node.js dependencies object for JavaScript and TypeScript code execution
-     * Format: { "package-name": "version", ... }
-     * Example: { "zod": "^3.0", "axios": "latest" }
+     * Node.js dependencies for JavaScript and TypeScript code execution.
+     * Accepts either npm CLI-style lines (one `package@version` per line, missing
+     * `@version` defaults to `latest`) or a JSON object (`{ "pkg": "version" }`).
      */
-    nodeDependencies?: Record<string, string>;
+    nodeDependencies?: string;
 
     /**
      * Python requirements in requirements.txt format for Python code execution

--- a/sandbox/tests/e2e.ts
+++ b/sandbox/tests/e2e.ts
@@ -933,9 +933,7 @@ async function main(): Promise<void> {
         console.log(`${colors.green}ℹ${colors.reset} Step 1: Preparing Actor input with dependencies...`);
 
         const input = {
-            nodeDependencies: {
-                zod: '^3.22.0',
-            },
+            nodeDependencies: 'zod@^3.22.0',
             pythonRequirementsTxt: 'numpy>=1.24.0',
             envVars: 'TEST_E2E_SECRET=hunter2-do-not-leak',
             initShellScript: [

--- a/sandbox/tests/unit/node-deps.test.ts
+++ b/sandbox/tests/unit/node-deps.test.ts
@@ -1,0 +1,181 @@
+/* eslint-disable @typescript-eslint/no-floating-promises -- node:test's describe/it return promises by design */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { parseNodeDependencies } from '../../src/node-deps.js';
+
+describe('parseNodeDependencies', () => {
+    describe('empty input', () => {
+        it('returns {} for undefined', () => {
+            assert.deepEqual(parseNodeDependencies(undefined), {});
+        });
+
+        it('returns {} for null', () => {
+            assert.deepEqual(parseNodeDependencies(null), {});
+        });
+
+        it('returns {} for empty string', () => {
+            assert.deepEqual(parseNodeDependencies(''), {});
+        });
+
+        it('returns {} for whitespace-only input', () => {
+            assert.deepEqual(parseNodeDependencies('   \n  \t  \n'), {});
+        });
+    });
+
+    describe('npm CLI-style line format', () => {
+        it('parses a single package@version line', () => {
+            assert.deepEqual(parseNodeDependencies('zod@^3.0'), { zod: '^3.0' });
+        });
+
+        it('parses multiple packages, one per line', () => {
+            const input = 'zod@^3.0\naxios@latest\nlodash@4.17.21';
+            assert.deepEqual(parseNodeDependencies(input), {
+                zod: '^3.0',
+                axios: 'latest',
+                lodash: '4.17.21',
+            });
+        });
+
+        it('defaults bare package names to latest', () => {
+            assert.deepEqual(parseNodeDependencies('lodash'), { lodash: 'latest' });
+        });
+
+        it('defaults bare names to latest in mixed input', () => {
+            const input = 'zod@^3.0\nlodash\naxios@latest';
+            assert.deepEqual(parseNodeDependencies(input), {
+                zod: '^3.0',
+                lodash: 'latest',
+                axios: 'latest',
+            });
+        });
+
+        it('handles scoped packages without version', () => {
+            assert.deepEqual(parseNodeDependencies('@types/node'), { '@types/node': 'latest' });
+        });
+
+        it('handles scoped packages with version (splits on last @)', () => {
+            assert.deepEqual(parseNodeDependencies('@types/node@^20'), { '@types/node': '^20' });
+        });
+
+        it('handles mixed scoped and unscoped packages', () => {
+            const input = '@types/node@^20\nzod@^3.0\n@apify/sdk';
+            assert.deepEqual(parseNodeDependencies(input), {
+                '@types/node': '^20',
+                zod: '^3.0',
+                '@apify/sdk': 'latest',
+            });
+        });
+
+        it('ignores blank lines', () => {
+            const input = '\n\nzod@^3.0\n\n\naxios@latest\n\n';
+            assert.deepEqual(parseNodeDependencies(input), {
+                zod: '^3.0',
+                axios: 'latest',
+            });
+        });
+
+        it('ignores # comment lines', () => {
+            const input = '# my deps\nzod@^3.0\n# another comment\naxios@latest';
+            assert.deepEqual(parseNodeDependencies(input), {
+                zod: '^3.0',
+                axios: 'latest',
+            });
+        });
+
+        it('trims whitespace around package specs', () => {
+            const input = '   zod@^3.0   \n\t axios@latest\t';
+            assert.deepEqual(parseNodeDependencies(input), {
+                zod: '^3.0',
+                axios: 'latest',
+            });
+        });
+
+        it('handles \\r\\n line endings', () => {
+            assert.deepEqual(parseNodeDependencies('zod@^3.0\r\naxios@latest'), {
+                zod: '^3.0',
+                axios: 'latest',
+            });
+        });
+
+        it('treats trailing @ as latest', () => {
+            assert.deepEqual(parseNodeDependencies('zod@'), { zod: 'latest' });
+        });
+
+        it('lets later duplicate entries override earlier ones', () => {
+            assert.deepEqual(parseNodeDependencies('zod@^3.0\nzod@^4.0'), { zod: '^4.0' });
+        });
+    });
+
+    describe('JSON object format', () => {
+        it('parses a JSON object', () => {
+            const input = '{"zod": "^3.0", "axios": "latest"}';
+            assert.deepEqual(parseNodeDependencies(input), {
+                zod: '^3.0',
+                axios: 'latest',
+            });
+        });
+
+        it('parses pretty-printed JSON', () => {
+            const input = '{\n  "zod": "^3.0",\n  "axios": "latest"\n}';
+            assert.deepEqual(parseNodeDependencies(input), {
+                zod: '^3.0',
+                axios: 'latest',
+            });
+        });
+
+        it('parses JSON with leading whitespace', () => {
+            assert.deepEqual(parseNodeDependencies('   {"zod": "^3.0"}   '), { zod: '^3.0' });
+        });
+
+        it('coerces numeric versions to strings', () => {
+            const input = '{"lodash": 4}';
+            assert.deepEqual(parseNodeDependencies(input), { lodash: '4' });
+        });
+
+        it('treats null/empty values as latest', () => {
+            const input = '{"zod": null, "axios": ""}';
+            assert.deepEqual(parseNodeDependencies(input), {
+                zod: 'latest',
+                axios: 'latest',
+            });
+        });
+
+        it('skips object/array values', () => {
+            const input = '{"zod": "^3.0", "bad": {"nested": true}, "alsobad": [1, 2]}';
+            assert.deepEqual(parseNodeDependencies(input), { zod: '^3.0' });
+        });
+
+        it('returns {} for malformed JSON', () => {
+            assert.deepEqual(parseNodeDependencies('{not valid json'), {});
+        });
+
+        it('returns {} for top-level JSON array (must be a flat object)', () => {
+            // Wrapped in `{}` so it routes to JSON parsing; bare `[...]` would be
+            // treated as line-format input by design.
+            assert.deepEqual(parseNodeDependencies('{"deps": ["zod", "axios"]}'), {});
+        });
+
+        it('parses an empty JSON object as {}', () => {
+            assert.deepEqual(parseNodeDependencies('{}'), {});
+        });
+
+        it('handles scoped packages in JSON', () => {
+            const input = '{"@types/node": "^20", "@apify/sdk": "latest"}';
+            assert.deepEqual(parseNodeDependencies(input), {
+                '@types/node': '^20',
+                '@apify/sdk': 'latest',
+            });
+        });
+    });
+
+    describe('format detection', () => {
+        it('treats input starting with { as JSON', () => {
+            assert.deepEqual(parseNodeDependencies('{"zod": "^3.0"}'), { zod: '^3.0' });
+        });
+
+        it('treats input not starting with { as line format', () => {
+            assert.deepEqual(parseNodeDependencies('zod@^3.0'), { zod: '^3.0' });
+        });
+    });
+});


### PR DESCRIPTION
## Summary

This PR adds a new `parseNodeDependencies()` function that accepts Node.js package dependencies in two flexible formats: npm CLI-style lines (`package@version` per line) or JSON objects. The input type is changed from a structured object to a string, with parsing happening at runtime to support both formats transparently.

## Key Changes

- **New module `src/node-deps.ts`**: Implements `parseNodeDependencies()` with dual-format support:
  - **Line format** (npm CLI style): one `package@version` per line, with support for scoped packages (`@scope/name@version`), comments (`#`), and blank lines. Missing `@version` defaults to `latest`.
  - **JSON format**: flat object `{ "package": "version" }` with automatic coercion of numeric versions to strings and null/empty values to `latest`.
  - Format detection: input starting with `{` is treated as JSON; otherwise parsed as lines.

- **Comprehensive test suite `tests/node-deps.test.ts`**: 30+ unit tests covering:
  - Empty/whitespace input handling
  - Scoped and unscoped packages
  - Comment and blank line filtering
  - Whitespace trimming and line ending normalization
  - JSON parsing with edge cases (malformed JSON, non-string values, nested objects)
  - Duplicate package handling (last entry wins)

- **Type and input changes**:
  - `ActorInput.nodeDependencies` changed from `Record<string, string>` to `string` in `src/types.ts`
  - Actor input schema updated in `.actor/actor.json`: field type changed to `textarea` with updated description and examples
  - `src/main.ts` now calls `parseNodeDependencies()` to convert string input to the internal object format

- **Documentation updates**:
  - `README.md`: Added examples of both input formats with clear formatting
  - `AGENTS.md`: Added unit testing guide with template and best practices
  - E2E test updated to use new line format: `'zod@^3.22.0'` instead of object

## Implementation Details

- **Scoped package handling**: The parser correctly splits on the *last* `@` to distinguish between scope separator and version separator (e.g., `@types/node@^20` → name: `@types/node`, version: `^20`).
- **Graceful degradation**: Malformed JSON returns `{}` with a warning log; invalid lines in line format are skipped with warnings.
- **No new dependencies**: Tests use Node's built-in `node:test` runner and `node:assert` module, requiring no additional packages.

https://claude.ai/code/session_011t31rBsLpeNZBwUUsPtFkV