### PR TITLE
Add envVars parsing and lifecycle management with tests

### DIFF
--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -30,6 +30,10 @@ RUN npm install
 # Compile TypeScript to JavaScript
 RUN npm run build
 
+# Run unit tests (fast, no platform dependency). E2E tests are run separately
+# via `npm run test:e2e` since they require a deployed Apify run.
+RUN npm run test:unit
+
 # Stage 2: Runtime - Node.js image
 FROM node:24-trixie-slim
 

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -32,7 +32,10 @@ RUN npm run build
 
 # Run unit tests (fast, no platform dependency). E2E tests are run separately
 # via `npm run test:e2e` since they require a deployed Apify run.
-RUN npm run test:unit
+# Skip if APIFY_IS_AT_HOME is set — defence-in-depth against accidentally
+# running tests during an Actor run (Dockerfile RUN is build-time only, so
+# this is belt-and-braces).
+RUN [ -n "$APIFY_IS_AT_HOME" ] || npm run test:unit
 
 # Stage 2: Runtime - Node.js image
 FROM node:24-trixie-slim

--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -45,7 +45,8 @@
         "lint:fix": "eslint --fix",
         "format": "prettier --write .",
         "format:check": "prettier --check .",
-        "test": "[ -n \"$APIFY_IS_AT_HOME\" ] || echo \"ℹ️  No unit tests available. For E2E platform tests, run: npm run test:e2e\"",
+        "test": "npm run test:unit",
+        "test:unit": "node --import tsx --test tests/unit/*.test.ts",
         "test:e2e": "tsx tests/e2e.ts"
     },
     "author": "It's not you it's me",

--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -45,7 +45,7 @@
         "lint:fix": "eslint --fix",
         "format": "prettier --write .",
         "format:check": "prettier --check .",
-        "test": "npm run test:unit",
+        "test": "npm run test:unit && npm run test:e2e",
         "test:unit": "node --import tsx --test tests/unit/*.test.ts",
         "test:e2e": "tsx tests/e2e.ts"
     },

--- a/sandbox/tests/e2e.ts
+++ b/sandbox/tests/e2e.ts
@@ -345,6 +345,51 @@ async function testEndpointWithOutputValidation(
     }
 }
 
+/**
+ * Run a /exec command and assert that the secret value does NOT appear in the
+ * output. Used to verify envVars are stripped from the runtime execution
+ * context after the init script. The command should print the env var wrapped
+ * in markers (e.g. `<<value>>`) so we can distinguish leak from absent value.
+ */
+async function testEndpointWithLeakAssertion(
+    baseUrl: string,
+    body: unknown,
+    forbiddenValue: string,
+    testName: string,
+): Promise<void> {
+    try {
+        const url = `${baseUrl}/exec`;
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+
+        const data = (await response.json()) as { stdout?: string; stderr?: string };
+
+        if (response.status !== 200) {
+            const errorMsg = `Expected status 200, got ${response.status}`;
+            console.log(`${colors.red}✗${colors.reset} ${testName}: ${errorMsg}`);
+            results.push({ name: testName, passed: false, error: errorMsg });
+            return;
+        }
+
+        const combined = `${data.stdout ?? ''}\n${data.stderr ?? ''}`;
+        if (combined.includes(forbiddenValue)) {
+            const errorMsg = `Forbidden value "${forbiddenValue}" leaked into output: "${combined.trim()}"`;
+            console.log(`${colors.red}✗${colors.reset} ${testName}: ${errorMsg}`);
+            results.push({ name: testName, passed: false, error: errorMsg });
+        } else {
+            console.log(`${colors.green}✓${colors.reset} ${testName}`);
+            results.push({ name: testName, passed: true });
+        }
+    } catch (error) {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        console.log(`${colors.red}✗${colors.reset} ${testName}: ${errorMsg}`);
+        results.push({ name: testName, passed: false, error: errorMsg });
+    }
+}
+
 async function testFsEndpoint(
     baseUrl: string,
     method: string,
@@ -427,6 +472,54 @@ async function runAllTests(baseUrl: string): Promise<void> {
         console.log(`${colors.red}✗${colors.reset} Init script - Verify file content: ${errorMsg}`);
         results.push({ name: 'Init script - Verify file content', passed: false, error: errorMsg });
     }
+
+    // ========================================================================
+    // envVars Lifecycle: visible to init script, deleted from runtime context
+    // ========================================================================
+
+    // Init script must have seen TEST_E2E_SECRET — proves envVars are exposed
+    // to the install/init phase as documented.
+    try {
+        const url = `${baseUrl}/fs/test-e2e-init/init-saw-secret.txt`;
+        const response = await fetch(url);
+        const content = (await response.text()).trim();
+
+        if (response.status === 200 && content === 'hunter2-do-not-leak') {
+            console.log(`${colors.green}✓${colors.reset} envVars - Init script received TEST_E2E_SECRET`);
+            results.push({ name: 'envVars - Init script received TEST_E2E_SECRET', passed: true });
+        } else {
+            const errorMsg = `Expected init script to write "hunter2-do-not-leak", got: "${content}" (status ${response.status})`;
+            console.log(`${colors.red}✗${colors.reset} envVars - Init script received TEST_E2E_SECRET: ${errorMsg}`);
+            results.push({ name: 'envVars - Init script received TEST_E2E_SECRET', passed: false, error: errorMsg });
+        }
+    } catch (error) {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        console.log(`${colors.red}✗${colors.reset} envVars - Init script received TEST_E2E_SECRET: ${errorMsg}`);
+        results.push({ name: 'envVars - Init script received TEST_E2E_SECRET', passed: false, error: errorMsg });
+    }
+
+    // Shell /exec must NOT see the secret. We print a marker before/after so
+    // we can distinguish "empty value" from "command failed". A leaked value
+    // would appear between the markers.
+    await testEndpointWithLeakAssertion(
+        baseUrl,
+        // eslint-disable-next-line no-template-curly-in-string -- shell interpolation, not JS
+        { command: 'printf "<<%s>>" "${TEST_E2E_SECRET}"' },
+        'hunter2-do-not-leak',
+        'envVars - Shell /exec does not see TEST_E2E_SECRET',
+    );
+
+    // Node /exec must NOT see the secret either (different code path: node
+    // child_process inherits process.env from the server).
+    await testEndpointWithLeakAssertion(
+        baseUrl,
+        {
+            command: 'console.log("<<" + (process.env.TEST_E2E_SECRET ?? "") + ">>")',
+            language: 'js',
+        },
+        'hunter2-do-not-leak',
+        'envVars - Node /exec does not see TEST_E2E_SECRET',
+    );
 
     // Execute command - success
     await testEndpoint(
@@ -844,8 +937,16 @@ async function main(): Promise<void> {
                 zod: '^3.22.0',
             },
             pythonRequirementsTxt: 'numpy>=1.24.0',
-            initShellScript:
-                "#!/bin/bash\nmkdir -p /sandbox/test-e2e-init\necho 'E2E test init script executed' > /sandbox/test-e2e-init/status.txt",
+            envVars: 'TEST_E2E_SECRET=hunter2-do-not-leak',
+            initShellScript: [
+                '#!/bin/bash',
+                'mkdir -p /sandbox/test-e2e-init',
+                "echo 'E2E test init script executed' > /sandbox/test-e2e-init/status.txt",
+                // Capture whether the secret was visible to the init script. We write
+                // the value (not just a flag) so the e2e suite can confirm it matched.
+                // eslint-disable-next-line no-template-curly-in-string -- shell interpolation, not JS
+                'echo "${TEST_E2E_SECRET:-<unset>}" > /sandbox/test-e2e-init/init-saw-secret.txt',
+            ].join('\n'),
         };
 
         console.log(

--- a/sandbox/tests/unit/env-vars.test.ts
+++ b/sandbox/tests/unit/env-vars.test.ts
@@ -1,0 +1,115 @@
+/* eslint-disable @typescript-eslint/no-floating-promises -- node:test's describe/it return promises by design */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { parseEnvVars } from '../../src/env-vars.js';
+
+describe('parseEnvVars', () => {
+    describe('empty / nullish input', () => {
+        it('returns {} for undefined', () => {
+            assert.deepEqual(parseEnvVars(undefined), {});
+        });
+
+        it('returns {} for null', () => {
+            assert.deepEqual(parseEnvVars(null), {});
+        });
+
+        it('returns {} for empty string', () => {
+            assert.deepEqual(parseEnvVars(''), {});
+        });
+
+        it('returns {} for whitespace-only string', () => {
+            assert.deepEqual(parseEnvVars('   \n\t  '), {});
+        });
+    });
+
+    describe('JSON object input', () => {
+        it('parses a flat object of strings', () => {
+            assert.deepEqual(parseEnvVars('{"FOO":"bar","BAZ":"qux"}'), { FOO: 'bar', BAZ: 'qux' });
+        });
+
+        it('coerces scalar values (number, boolean) to strings', () => {
+            assert.deepEqual(parseEnvVars('{"PORT":3000,"DEBUG":true}'), { PORT: '3000', DEBUG: 'true' });
+        });
+
+        it('skips null and undefined values', () => {
+            assert.deepEqual(parseEnvVars('{"FOO":"bar","NIL":null}'), { FOO: 'bar' });
+        });
+
+        it('skips object and array values', () => {
+            assert.deepEqual(parseEnvVars('{"FOO":"bar","OBJ":{"x":1},"ARR":[1,2]}'), { FOO: 'bar' });
+        });
+
+        it('skips invalid keys (must start with letter or underscore)', () => {
+            assert.deepEqual(parseEnvVars('{"1FOO":"bad","FOO-BAR":"bad","_OK":"ok","GOOD2":"ok"}'), {
+                _OK: 'ok',
+                GOOD2: 'ok',
+            });
+        });
+
+        it('returns {} for malformed JSON', () => {
+            assert.deepEqual(parseEnvVars('{not json}'), {});
+        });
+
+        it('returns {} for JSON arrays at the top level', () => {
+            assert.deepEqual(parseEnvVars('[1,2,3]'), {});
+        });
+
+        it('tolerates leading whitespace before the opening brace', () => {
+            assert.deepEqual(parseEnvVars('   \n{"FOO":"bar"}'), { FOO: 'bar' });
+        });
+    });
+
+    describe('dotenv input', () => {
+        it('parses simple KEY=VALUE lines', () => {
+            assert.deepEqual(parseEnvVars('FOO=bar\nBAZ=qux'), { FOO: 'bar', BAZ: 'qux' });
+        });
+
+        it('handles the optional `export ` prefix', () => {
+            assert.deepEqual(parseEnvVars('export FOO=bar'), { FOO: 'bar' });
+        });
+
+        it('strips matching surrounding quotes (double and single)', () => {
+            assert.deepEqual(parseEnvVars('FOO="bar baz"\nBAZ=\'qux\''), { FOO: 'bar baz', BAZ: 'qux' });
+        });
+
+        it('does not strip mismatched quotes', () => {
+            assert.deepEqual(parseEnvVars(`FOO="bar'`), { FOO: `"bar'` });
+        });
+
+        it('preserves `=` characters in the value', () => {
+            assert.deepEqual(parseEnvVars('TOKEN=abc=def=ghi'), { TOKEN: 'abc=def=ghi' });
+        });
+
+        it('skips comment lines and blank lines', () => {
+            const input = ['# comment', '', 'FOO=bar', '   ', '# another', 'BAZ=qux'].join('\n');
+            assert.deepEqual(parseEnvVars(input), { FOO: 'bar', BAZ: 'qux' });
+        });
+
+        it('skips malformed lines (no `=`) but keeps valid ones', () => {
+            assert.deepEqual(parseEnvVars('FOO=bar\nNO_EQUALS_HERE\nBAZ=qux'), { FOO: 'bar', BAZ: 'qux' });
+        });
+
+        it('skips lines with invalid keys', () => {
+            assert.deepEqual(parseEnvVars('1FOO=bad\nFOO-BAR=bad\n_OK=ok'), { _OK: 'ok' });
+        });
+
+        it('handles CRLF line endings', () => {
+            assert.deepEqual(parseEnvVars('FOO=bar\r\nBAZ=qux\r\n'), { FOO: 'bar', BAZ: 'qux' });
+        });
+
+        it('allows empty values', () => {
+            assert.deepEqual(parseEnvVars('EMPTY='), { EMPTY: '' });
+        });
+    });
+
+    describe('format detection', () => {
+        it('treats input starting with `{` as JSON', () => {
+            assert.deepEqual(parseEnvVars('{"FOO":"bar"}'), { FOO: 'bar' });
+        });
+
+        it('treats input not starting with `{` as dotenv', () => {
+            assert.deepEqual(parseEnvVars('FOO=bar'), { FOO: 'bar' });
+        });
+    });
+});


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for environment variable management in the sandbox, including parsing from JSON or dotenv formats, exposing them to init scripts, and ensuring they're stripped from the runtime execution context.

## Key Changes

- **New `parseEnvVars()` function**: Parses environment variables from either JSON object or dotenv format (KEY=VALUE lines), with support for:
  - JSON objects with automatic type coercion (numbers/booleans → strings)
  - Dotenv format with `export` prefix, quote stripping, and CRLF handling
  - Validation of environment variable names (must start with letter or underscore)
  - Graceful handling of malformed input

- **Comprehensive unit test suite** (`sandbox/tests/unit/env-vars.test.ts`):
  - 20+ test cases covering empty/nullish input, JSON parsing, dotenv parsing, and format detection
  - Tests for edge cases: malformed JSON, invalid keys, mismatched quotes, empty values, CRLF line endings

- **E2E test enhancements**:
  - New `testEndpointWithLeakAssertion()` helper to verify secrets don't leak into runtime output
  - Tests confirming envVars are visible to init scripts but stripped from `/exec` commands (both shell and Node.js)
  - Updated test fixture to pass `TEST_E2E_SECRET` via envVars and verify init script access

- **Build and test infrastructure**:
  - Added `npm run test:unit` command to run unit tests with tsx
  - Updated main `test` script to run both unit and E2E tests
  - Added unit test execution to Docker build pipeline

## Notable Implementation Details

- Format detection is automatic: input starting with `{` is treated as JSON, otherwise as dotenv
- Environment variable names are validated against the pattern `^[a-zA-Z_][a-zA-Z0-9_]*$`
- Null, undefined, object, and array values are silently skipped in JSON input
- The implementation ensures envVars are available during sandbox initialization but removed from the runtime environment for security

https://claude.ai/code/session_01RB8opAq3wSQTeiKrUS3Rnw