### PR TITLE
Add MCP Connections support to sandbox startup

### DIFF
--- a/sandbox/.actor/actor.json
+++ b/sandbox/.actor/actor.json
@@ -86,6 +86,15 @@
                 },
                 "default": [],
                 "prefill": [{"path": "/myapp", "target": "http://127.0.0.1:3000/myapp"}]
+            },
+            "mcpConnections": {
+                "title": "MCP Connections",
+                "type": "array",
+                "description": "MCP Connectors the sandbox can call on your behalf — for example Slack, Notion, GitHub, or any other MCP server you have authorized in Settings > API & Integrations > MCP Connectors. At runtime the platform injects your credentials and exposes each Connector as a proxy at `${APIFY_MCP_PROXY_URL}/<connectorId>`. The sandbox writes the full list to `/sandbox/mcp.json` on startup so tools like `mcpc connect` can pick them up immediately.",
+                "resourceType": "mcpConnector",
+                "mcpServers": [{ "url": "*" }],
+                "editor": "resourcePicker",
+                "default": []
             }
         },
 

--- a/sandbox/artifacts/AGENTS.md
+++ b/sandbox/artifacts/AGENTS.md
@@ -144,6 +144,33 @@ mcpc @apify tools-list --json
 
 Access Apify platform features and thousands of Actors via `mcpc` tool.
 
+### User-provided MCP Connections (`/sandbox/mcp.json`)
+
+If the user picked **MCP Connectors** in the Actor input (e.g. Slack, Notion, GitHub), the sandbox writes them to `/sandbox/mcp.json` on startup. Each entry is a ready-to-use HTTP MCP proxy, authenticated with the user's credentials server-side:
+
+```bash
+cat /sandbox/mcp.json
+# {
+#   "mcpServers": {
+#     "conn_abc123": {
+#       "url": "https://api.apify.com/v2/mcp-proxy/conn_abc123",
+#       "headers": { "Authorization": "Bearer ${APIFY_TOKEN}" }
+#     }
+#   }
+# }
+```
+
+To connect with `mcpc`, read a server entry from the file and pass it to `mcpc connect`:
+
+```bash
+# Connect to the first user-provided Connector as @user1
+URL=$(jq -r '.mcpServers | to_entries[0].value.url' /sandbox/mcp.json)
+mcpc connect "$URL" @user1 --header "Authorization: Bearer $APIFY_TOKEN"
+mcpc @user1 tools-list --json
+```
+
+If `/sandbox/mcp.json` has `"mcpServers": {}`, the user provided no Connectors — fall back to the Apify MCP server below.
+
 ### 🚨 CRITICAL: Connect to Apify MCP Server First
 
 **Before using any MCP commands, you MUST create a named connection.** Direct URL connections are deprecated — always use named sessions with `@apify`.

--- a/sandbox/src/main.ts
+++ b/sandbox/src/main.ts
@@ -15,6 +15,7 @@ import { SANDBOX_DIR } from './consts.js';
 import { parseEnvVars } from './env-vars.js';
 import { executeInitScript, setupExecutionEnvironment, setUserEnvVars } from './environment.js';
 import { createMcpServer } from './mcp.js';
+import { writeMcpConfig } from './mcp-connections.js';
 import { parseNodeDependencies } from './node-deps.js';
 import {
     appendFile,
@@ -77,7 +78,14 @@ log.info('Actor input retrieved', {
     hasPythonRequirements: !!input?.pythonRequirementsTxt?.trim().length,
     hasInitScript: !!input?.initShellScript?.trim().length,
     envVarKeys: Object.keys(userEnvVars),
+    mcpConnectionCount: input?.mcpConnections?.length ?? 0,
 });
+
+// Write /sandbox/mcp.json with the configured MCP Connector proxies so
+// tools like `mcpc connect` find them as soon as the shell opens.
+if (!isLocalMode) {
+    writeMcpConfig(input?.mcpConnections);
+}
 
 // Check for migration state and restore if available
 let restoredFromMigration = false;

--- a/sandbox/src/mcp-connections.ts
+++ b/sandbox/src/mcp-connections.ts
@@ -1,0 +1,102 @@
+/**
+ * MCP Connections Module
+ *
+ * Writes /sandbox/mcp.json on sandbox start so tools like `mcpc connect`
+ * can immediately find the MCP Connector proxies provided via Actor input.
+ *
+ * Each input value is a Connector ID (e.g. "conn_abc123"). At runtime the
+ * platform exposes the matching MCP server as a proxy at
+ * `${APIFY_MCP_PROXY_URL}/<connectorId>`, authenticated with `APIFY_TOKEN`.
+ */
+
+/* eslint-disable no-template-curly-in-string -- ${APIFY_TOKEN} is a literal placeholder we write to mcp.json, not a JS template expression */
+
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import { log } from 'apify';
+
+import { SANDBOX_DIR } from './consts.js';
+
+export const MCP_CONFIG_PATH = `${SANDBOX_DIR}/mcp.json`;
+
+export interface McpServerEntry {
+    url: string;
+    headers: Record<string, string>;
+}
+
+export interface McpConfig {
+    mcpServers: Record<string, McpServerEntry>;
+}
+
+/**
+ * Sanitize a Connector ID for use as a JSON object key. We keep the ID as the
+ * key when it's already safe to read in a shell (alphanumeric, `_`, `-`); if
+ * not, we fall back to a sanitized version so the file is still well-formed.
+ */
+const toServerKey = (id: string): string => {
+    if (/^[A-Za-z0-9_-]+$/.test(id)) return id;
+    return id.replace(/[^A-Za-z0-9_-]/g, '_');
+};
+
+/**
+ * Build the MCP config object from a list of Connector IDs.
+ * Returns `{ mcpServers: {} }` when the input is empty/invalid so the file
+ * is still a valid, well-known shape downstream tools can read.
+ */
+export const buildMcpConfig = (
+    connectionIds: string[] | undefined,
+    proxyUrl: string | undefined,
+): McpConfig => {
+    const config: McpConfig = { mcpServers: {} };
+
+    if (!connectionIds || connectionIds.length === 0) return config;
+
+    const base = (proxyUrl || '').replace(/\/+$/, '');
+
+    for (const raw of connectionIds) {
+        if (typeof raw !== 'string') continue;
+        const id = raw.trim();
+        if (!id) continue;
+
+        const key = toServerKey(id);
+        config.mcpServers[key] = {
+            url: `${base}/${id}`,
+            headers: {
+                Authorization: 'Bearer ${APIFY_TOKEN}',
+            },
+        };
+    }
+
+    return config;
+};
+
+/**
+ * Write the MCP config to /sandbox/mcp.json. Always writes a file (even when
+ * the connection list is empty) so consumers can rely on its presence.
+ * Logs and swallows errors — a failed write must not abort sandbox startup.
+ */
+export const writeMcpConfig = (connectionIds: string[] | undefined): void => {
+    try {
+        const proxyUrl = process.env.APIFY_MCP_PROXY_URL;
+        const config = buildMcpConfig(connectionIds, proxyUrl);
+
+        const dir = dirname(MCP_CONFIG_PATH);
+        if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+        writeFileSync(MCP_CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`);
+
+        const count = Object.keys(config.mcpServers).length;
+        log.info('Wrote MCP connections config', { path: MCP_CONFIG_PATH, count });
+        if (count > 0 && !proxyUrl) {
+            log.warning(
+                'APIFY_MCP_PROXY_URL is not set; mcp.json entries point to an empty proxy base URL',
+            );
+        }
+    } catch (error) {
+        log.error('Failed to write MCP connections config', {
+            path: MCP_CONFIG_PATH,
+            error: (error as Error).message,
+        });
+    }
+};

--- a/sandbox/src/types.ts
+++ b/sandbox/src/types.ts
@@ -61,4 +61,12 @@ export interface ActorInput {
      * Example: [{ "path": "/openclaw", "target": "http://127.0.0.1:18789/openclaw" }]
      */
     proxyMappings?: ProxyMapping[];
+
+    /**
+     * MCP Connector IDs the Actor can use. At runtime the platform exposes
+     * each Connector as a proxy at `${APIFY_MCP_PROXY_URL}/<connectorId>`,
+     * and the sandbox writes the list to `/sandbox/mcp.json` on startup
+     * so tools like `mcpc connect` can pick them up.
+     */
+    mcpConnections?: string[];
 }

--- a/sandbox/tests/unit/mcp-connections.test.ts
+++ b/sandbox/tests/unit/mcp-connections.test.ts
@@ -1,0 +1,86 @@
+/* eslint-disable @typescript-eslint/no-floating-promises -- node:test's describe/it return promises by design */
+/* eslint-disable no-template-curly-in-string -- ${APIFY_TOKEN} is a literal placeholder we write to mcp.json, not a JS template expression */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { buildMcpConfig } from '../../src/mcp-connections.js';
+
+const PROXY = 'https://api.apify.com/v2/mcp-proxy';
+
+describe('buildMcpConfig', () => {
+    describe('empty / nullish input', () => {
+        it('returns an empty mcpServers map for undefined', () => {
+            assert.deepEqual(buildMcpConfig(undefined, PROXY), { mcpServers: {} });
+        });
+
+        it('returns an empty mcpServers map for an empty array', () => {
+            assert.deepEqual(buildMcpConfig([], PROXY), { mcpServers: {} });
+        });
+
+        it('skips blank / non-string entries', () => {
+            // @ts-expect-error - intentionally passing non-string to exercise runtime guard
+            const config = buildMcpConfig(['', '   ', null, 42, 'conn_ok'], PROXY);
+            assert.deepEqual(Object.keys(config.mcpServers), ['conn_ok']);
+        });
+    });
+
+    describe('valid Connector IDs', () => {
+        it('builds one server entry per Connector ID', () => {
+            const config = buildMcpConfig(['conn_abc123', 'conn_def456'], PROXY);
+            assert.deepEqual(config, {
+                mcpServers: {
+                    conn_abc123: {
+                        url: `${PROXY}/conn_abc123`,
+                        headers: { Authorization: 'Bearer ${APIFY_TOKEN}' },
+                    },
+                    conn_def456: {
+                        url: `${PROXY}/conn_def456`,
+                        headers: { Authorization: 'Bearer ${APIFY_TOKEN}' },
+                    },
+                },
+            });
+        });
+
+        it('uses ${APIFY_TOKEN} placeholder in Authorization header', () => {
+            const config = buildMcpConfig(['conn_abc'], PROXY);
+            assert.equal(config.mcpServers.conn_abc.headers.Authorization, 'Bearer ${APIFY_TOKEN}');
+        });
+
+        it('strips trailing slashes from the proxy base URL', () => {
+            const config = buildMcpConfig(['conn_abc'], `${PROXY}//`);
+            assert.equal(config.mcpServers.conn_abc.url, `${PROXY}/conn_abc`);
+        });
+
+        it('trims whitespace around Connector IDs', () => {
+            const config = buildMcpConfig(['  conn_abc  '], PROXY);
+            assert.deepEqual(Object.keys(config.mcpServers), ['conn_abc']);
+            assert.equal(config.mcpServers.conn_abc.url, `${PROXY}/conn_abc`);
+        });
+    });
+
+    describe('proxy URL handling', () => {
+        it('falls back to an empty base when proxy URL is undefined', () => {
+            const config = buildMcpConfig(['conn_abc'], undefined);
+            assert.equal(config.mcpServers.conn_abc.url, '/conn_abc');
+        });
+
+        it('falls back to an empty base when proxy URL is empty string', () => {
+            const config = buildMcpConfig(['conn_abc'], '');
+            assert.equal(config.mcpServers.conn_abc.url, '/conn_abc');
+        });
+    });
+
+    describe('key sanitization', () => {
+        it('uses the raw ID as the key when it is safe', () => {
+            const config = buildMcpConfig(['Conn-123_abc'], PROXY);
+            assert.ok('Conn-123_abc' in config.mcpServers);
+        });
+
+        it('sanitizes IDs that contain unsafe characters', () => {
+            const config = buildMcpConfig(['conn@abc/xyz'], PROXY);
+            assert.ok('conn_abc_xyz' in config.mcpServers);
+            // URL preserves the original ID so the proxy can route correctly
+            assert.equal(config.mcpServers.conn_abc_xyz.url, `${PROXY}/conn@abc/xyz`);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
This PR adds support for MCP (Model Context Protocol) Connectors in the sandbox. When users select MCP Connectors (like Slack, Notion, GitHub) in the Actor input, the sandbox now writes them to `/sandbox/mcp.json` on startup, making them immediately available to tools like `mcpc connect`.

## Key Changes

- **New MCP Connections Module** (`sandbox/src/mcp-connections.ts`):
  - `buildMcpConfig()`: Constructs MCP server configuration from Connector IDs, building proxy URLs and authentication headers
  - `writeMcpConfig()`: Writes the configuration to `/sandbox/mcp.json` on sandbox startup
  - Includes sanitization for Connector IDs used as JSON keys while preserving original IDs in URLs
  - Gracefully handles missing/empty inputs and logs warnings when proxy URL is not configured

- **Comprehensive Unit Tests** (`sandbox/tests/unit/mcp-connections.test.ts`):
  - Tests for empty/nullish inputs, valid Connector IDs, proxy URL handling, and key sanitization
  - Validates that `${APIFY_TOKEN}` placeholder is preserved in Authorization headers for runtime substitution

- **Actor Input Integration** (`sandbox/src/types.ts`):
  - Added `mcpConnections?: string[]` field to `ActorInput` interface to accept Connector IDs

- **Actor Configuration** (`sandbox/.actor/actor.json`):
  - Added `mcpConnections` input field with resource picker UI for selecting MCP Connectors

- **Sandbox Startup** (`sandbox/src/main.ts`):
  - Integrated `writeMcpConfig()` call during sandbox initialization (non-local mode only)
  - Logs the count of configured MCP connections

- **Documentation** (`sandbox/artifacts/AGENTS.md`):
  - Added section explaining user-provided MCP Connections with example usage and fallback behavior

## Implementation Details

- The module writes `/sandbox/mcp.json` even when the connection list is empty, ensuring downstream tools can rely on its presence
- Connector IDs are sanitized for use as JSON object keys (alphanumeric, `_`, `-` are safe; others replaced with `_`)
- Original Connector IDs are preserved in proxy URLs for correct routing
- Authorization headers use `Bearer ${APIFY_TOKEN}` as a literal placeholder for runtime token substitution
- Errors during file write are logged but don't abort sandbox startup
- Trailing slashes are stripped from proxy base URLs to prevent double slashes in constructed URLs

https://claude.ai/code/session_01Kqvg4XLUCnqzWekWN889DJ