### PR TITLE
Improve sandbox configuration prefill examples and documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Repo conventions for Claude
+
+## Pull requests
+- Keep PR descriptions short: 2-4 bullets covering what changed and why. No "Summary / Key Changes / Implementation Details" sections, no restating the diff. The diff is the record of what changed; the description explains intent.
+- Title should be a single short imperative sentence (<70 chars).

--- a/claude-code/.actor/actor.json
+++ b/claude-code/.actor/actor.json
@@ -31,7 +31,7 @@
         "type": "string",
         "description": "Optional bash script to run on startup for installing packages or setting up the environment.",
         "editor": "textarea",
-        "prefill": "apt-get update\n# apt-get install -y curl"
+        "prefill": "#!/bin/bash\n# Optional bash script run on startup.\n# Uncomment lines below or add your own:\n# apt-get update\n# apt-get install -y curl jq\n# mkdir -p /sandbox/data\n# echo 'export MY_VAR=hello' >> /sandbox/.bashrc"
       },
       "envVars": {
         "title": "Environment variables",

--- a/openclaw/.actor/actor.json
+++ b/openclaw/.actor/actor.json
@@ -31,7 +31,7 @@
         "type": "string",
         "description": "Optional bash script to run on startup for installing packages or setting up the environment.",
         "editor": "textarea",
-        "prefill": "apt-get update\n# apt-get install -y curl"
+        "prefill": "#!/bin/bash\n# Optional bash script run on startup.\n# Uncomment lines below or add your own:\n# apt-get update\n# apt-get install -y curl jq\n# mkdir -p /sandbox/data\n# echo 'export MY_VAR=hello' >> /sandbox/.bashrc"
       },
       "envVars": {
         "title": "Environment variables",

--- a/opencode/.actor/actor.json
+++ b/opencode/.actor/actor.json
@@ -31,7 +31,7 @@
         "type": "string",
         "description": "Optional bash script to run on startup for installing packages or setting up the environment.",
         "editor": "textarea",
-        "prefill": "apt-get update\n# apt-get install -y curl"
+        "prefill": "#!/bin/bash\n# Optional bash script run on startup.\n# Uncomment lines below or add your own:\n# apt-get update\n# apt-get install -y curl jq\n# mkdir -p /sandbox/data\n# echo 'export MY_VAR=hello' >> /sandbox/.bashrc"
       },
       "envVars": {
         "title": "Environment variables",

--- a/sandbox/.actor/actor.json
+++ b/sandbox/.actor/actor.json
@@ -32,21 +32,21 @@
                 "type": "string",
                 "description": "npm packages to install for JavaScript and TypeScript code execution (/sandbox/js-ts).\n\nAccepts either format:\n- **One `package@version` per line** (npm CLI style):\n  ```\n  zod@^3.0\n  axios@latest\n  lodash\n  ```\n  Lines without `@version` default to `latest`. Blank lines and `#` comments are ignored. Scoped packages like `@types/node@^20` are supported.\n- **JSON object** (package.json `dependencies` style):\n  ```\n  {\"zod\": \"^3.0\", \"axios\": \"latest\"}\n  ```",
                 "editor": "textarea",
-                "prefill": "# One package@version per line. Omit @version for latest.\n# zod@^3.0\n# axios@latest\n# @types/node@^20"
+                "prefill": "# One package@version per line. Omit @version for latest.\n# Uncomment lines below or add your own:\n# zod@^3.0\n# axios@latest\n# lodash\n# @types/node@^20\n#\n# Or use JSON object format (package.json dependencies style):\n# {\"zod\": \"^3.0\", \"axios\": \"latest\"}"
             },
             "pythonRequirementsTxt": {
                 "title": "Python requirements",
                 "type": "string",
                 "description": "Python requirements in requirements.txt format for Python code execution (/sandbox/py). Paste your dependencies one per line. Example:\n requests==2.31.0\npandas>=2.0.0",
                 "editor": "textarea",
-                "prefill": ""
+                "prefill": "# One package per line, in requirements.txt format.\n# Uncomment lines below or add your own:\n# requests==2.31.0\n# pandas>=2.0.0\n# numpy\n# beautifulsoup4>=4.12"
             },
             "initShellScript": {
                 "title": "Initialization script",
                 "type": "string",
                 "description": "Optional bash script to customize the sandbox environment. Runs after library installation in /sandbox directory. Use for installing system packages, creating directories, or other setup tasks.",
                 "editor": "textarea",
-                "prefill": "apt-get update\n# apt-get install -y curl\n# mkdir /sandbox/data"
+                "prefill": "#!/bin/bash\n# Optional bash script run on startup, after dependencies are installed.\n# Uncomment lines below or add your own:\n# apt-get update\n# apt-get install -y curl jq\n# mkdir -p /sandbox/data\n# echo 'export MY_VAR=hello' >> /sandbox/.bashrc"
             },
             "envVars": {
                 "title": "Environment variables",

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -65,8 +65,7 @@ RUN npm install -g tsx
 RUN npm install -g --ignore-scripts apify-cli
 
 # Install Apify MCP CLI globally (package: @apify/mcpc, binary: mcpc)
-# Using beta for named connection support (mcpc connect ... @session)
-RUN npm install -g @apify/mcpc@beta
+RUN npm install -g @apify/mcpc
 
 # Install Claude Code CLI
 RUN curl -fsSL https://claude.ai/install.sh | bash


### PR DESCRIPTION
- Comment out the example lines in `initShellScript`, `nodeDependencies`, and `pythonRequirementsTxt` prefills so defaults have no effect; users uncomment what they need.
- Switch `@apify/mcpc@beta` to stable `@apify/mcpc` in `sandbox/Dockerfile`.

https://claude.ai/code/session_0115MxnEh2NxRT2cfkNjGEfu