### PR TITLE
Add shutdown notifications to browser terminals

### DIFF
--- a/sandbox/src/main.ts
+++ b/sandbox/src/main.ts
@@ -38,6 +38,7 @@ import {
     removeProxyMapping,
     onMappingsChange,
 } from './proxy-config.js';
+import { broadcastToTerminals, buildShutdownBanner } from './shutdown.js';
 import { getLandingPageHTML, getLLMsMarkdown } from './templates/landing.js';
 import { SANDBOX_BASHRC, WELCOME_SCRIPT } from './templates/shell.js';
 import type { ActorInput, ProxyMapping } from './types.js';
@@ -894,6 +895,48 @@ if (!isLocalMode) {
     spawnTtyd();
 }
 
+// ============================================================================
+// Shutdown notifications
+// ============================================================================
+
+/** Delay before exiting so ttyd can flush the banner to connected browsers. */
+const TERMINAL_FLUSH_DELAY_MS = 1000;
+
+/**
+ * Show a shutdown banner in every open browser terminal. No-op in local mode,
+ * where /dev/pts would hold the developer's own terminals rather than ttyd's.
+ * @param reason - Human-readable explanation of why the Actor is stopping.
+ */
+const notifyTerminalsOfShutdown = (reason: string): void => {
+    if (isLocalMode) return;
+    broadcastToTerminals(buildShutdownBanner(reason, process.env.ACTOR_RUN_ID));
+};
+
+/**
+ * Notify open terminals, then exit the Actor. The brief delay lets ttyd flush
+ * the banner over the WebSocket before the process tears down the connection
+ * (after which the terminal only shows ttyd's "Press ⏎ to Reconnect" overlay).
+ * @param reason - Human-readable explanation of why the Actor is stopping.
+ */
+const shutdownWithNotice = async (reason: string): Promise<void> => {
+    notifyTerminalsOfShutdown(reason);
+    await new Promise((resolve) => {
+        setTimeout(resolve, TERMINAL_FLUSH_DELAY_MS);
+    });
+    await Actor.exit({ statusMessage: reason });
+};
+
+// Surface platform-initiated stops (migration, abort) in the terminal too. These
+// fire synchronously; the platform controls process exit, so we only broadcast.
+if (!isLocalMode) {
+    Actor.on('migrating', () => {
+        notifyTerminalsOfShutdown('Actor is migrating to a new host and will resume shortly. Reconnect in a moment.');
+    });
+    Actor.on('aborting', () => {
+        notifyTerminalsOfShutdown('Actor run is being aborted.');
+    });
+}
+
 // Manual HTTP Proxy for ttyd
 app.all('/shell{*rest}', (req, res) => {
     let path = req.url.replace(/^\/shell/, '') || '/';
@@ -1245,7 +1288,7 @@ server.listen(port, () => {
             if (idleTimeMs > idleTimeoutSecs * 1000) {
                 const message = `Actor shut down after ${Math.floor(idleTimeoutSecs / 60)} minutes of inactivity.`;
                 log.warning(message);
-                await Actor.exit({ statusMessage: message });
+                await shutdownWithNotice(message);
             }
         }, 30000); // Check every 30 seconds
     }

--- a/sandbox/src/shutdown.ts
+++ b/sandbox/src/shutdown.ts
@@ -1,0 +1,90 @@
+/**
+ * Terminal shutdown notifications.
+ *
+ * The browser terminal is served by ttyd, which spawns bash on a PTY (one slave
+ * device under /dev/pts per connected browser). When the container stops, ttyd
+ * dies and the WebSocket drops, at which point the client only shows its
+ * "Press ⏎ to Reconnect" overlay. To tell the user *why* the session ended, we
+ * write a banner to the PTY slave devices first: bytes written there reach the
+ * PTY master, which ttyd forwards to the browser, so the text shows up in the
+ * live terminal before it disconnects.
+ */
+
+import { closeSync, constants, openSync, readdirSync, writeSync } from 'node:fs';
+
+/** Directory holding PTY slave devices for connected terminal sessions. */
+const PTS_DIR = '/dev/pts';
+
+/**
+ * Write a message to every active terminal session.
+ *
+ * Safe to call when nothing is connected: if the directory is missing or empty
+ * (e.g. no open terminals) it is a no-op. Individual write failures are ignored
+ * so one stuck terminal can't block the others or the shutdown itself.
+ *
+ * @param message - Raw bytes to write. Use `\r\n` line breaks: terminals are in
+ *   raw mode, so a bare `\n` would not return the cursor to column 0.
+ * @param ptsDir - PTY device directory; overridable for testing.
+ */
+export const broadcastToTerminals = (message: string, ptsDir: string = PTS_DIR): void => {
+    let entries: string[];
+    try {
+        entries = readdirSync(ptsDir);
+    } catch {
+        // No /dev/pts (or unreadable) — nothing to notify.
+        return;
+    }
+
+    for (const entry of entries) {
+        // Slave devices are numeric (e.g. "0", "1"); skip "ptmx" and anything else.
+        if (!/^\d+$/.test(entry)) continue;
+
+        try {
+            // O_NONBLOCK so a terminal whose buffer is full can't stall shutdown.
+            // eslint-disable-next-line no-bitwise -- combining open() flags requires bitwise OR
+            const fd = openSync(`${ptsDir}/${entry}`, constants.O_WRONLY | constants.O_NONBLOCK);
+            try {
+                writeSync(fd, message);
+            } finally {
+                closeSync(fd);
+            }
+        } catch {
+            // Terminal may have disconnected between readdir and write — ignore.
+        }
+    }
+};
+
+/**
+ * Build the banner shown in open terminals when the Actor stops.
+ *
+ * @param reason - Human-readable explanation of why the Actor is stopping.
+ * @param runId - Actor run ID used to build a "restart" link (omitted if absent).
+ * @returns ANSI-styled text with `\r\n` line breaks, ready to write to a terminal.
+ */
+export const buildShutdownBanner = (reason: string, runId?: string): string => {
+    const BOLD_YELLOW = '\x1b[1;33m';
+    const CYAN = '\x1b[0;36m';
+    const DIM = '\x1b[2m';
+    const RESET = '\x1b[0m';
+    const RULE = '='.repeat(52);
+
+    const lines: string[] = [
+        '',
+        `${BOLD_YELLOW}${RULE}${RESET}`,
+        `${BOLD_YELLOW}Apify AI Sandbox is shutting down${RESET}`,
+        '',
+        reason,
+    ];
+
+    if (runId) {
+        lines.push(
+            '',
+            `${DIM}Restart the Actor to start a new session:${RESET}`,
+            `${CYAN}https://console.apify.com/view/runs/${runId}${RESET}`,
+        );
+    }
+
+    lines.push(`${BOLD_YELLOW}${RULE}${RESET}`, '');
+
+    return `${lines.join('\r\n')}\r\n`;
+};

--- a/sandbox/tests/unit/shutdown.test.ts
+++ b/sandbox/tests/unit/shutdown.test.ts
@@ -1,0 +1,39 @@
+/* eslint-disable @typescript-eslint/no-floating-promises -- node:test's describe/it return promises by design */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { broadcastToTerminals, buildShutdownBanner } from '../../src/shutdown.js';
+
+describe('buildShutdownBanner', () => {
+    it('includes the shutdown headline and the reason', () => {
+        const banner = buildShutdownBanner('Out for lunch.');
+        assert.ok(banner.includes('Apify AI Sandbox is shutting down'));
+        assert.ok(banner.includes('Out for lunch.'));
+    });
+
+    it('uses CRLF line endings for raw-mode terminals', () => {
+        const banner = buildShutdownBanner('reason');
+        // A bare \n (not preceded by \r) would not return the cursor to column 0.
+        for (let i = 0; i < banner.length; i += 1) {
+            if (banner[i] === '\n') {
+                assert.equal(banner[i - 1], '\r', `bare \\n at index ${i}`);
+            }
+        }
+    });
+
+    it('includes a restart link when a run ID is provided', () => {
+        const banner = buildShutdownBanner('reason', 'RUN123');
+        assert.ok(banner.includes('https://console.apify.com/view/runs/RUN123'));
+    });
+
+    it('omits the restart link when no run ID is provided', () => {
+        const banner = buildShutdownBanner('reason');
+        assert.ok(!banner.includes('console.apify.com'));
+    });
+});
+
+describe('broadcastToTerminals', () => {
+    it('does nothing and does not throw when the pts directory is absent', () => {
+        assert.doesNotThrow(() => broadcastToTerminals('hi', '/no/such/pts/dir'));
+    });
+});


### PR DESCRIPTION
## Summary
Add functionality to display shutdown banners in open browser terminals when the Actor stops, improving user experience by explaining why their session ended.

## Key Changes
- **New `shutdown.ts` module** with two main exports:
  - `broadcastToTerminals()`: Writes a message to all active PTY slave devices in `/dev/pts`, safely handling missing directories and individual write failures
  - `buildShutdownBanner()`: Constructs an ANSI-styled shutdown message with optional restart link, using CRLF line endings for raw-mode terminals

- **Updated `main.ts`** to integrate shutdown notifications:
  - Added `notifyTerminalsOfShutdown()` helper that broadcasts banners (skipped in local mode to avoid interfering with developer terminals)
  - Added `shutdownWithNotice()` that notifies terminals and waits 1 second before exiting, allowing ttyd to flush the message over WebSocket
  - Wired up platform-initiated shutdown events (`migrating`, `aborting`) to display appropriate messages
  - Changed idle timeout shutdown to use `shutdownWithNotice()` instead of direct `Actor.exit()`

- **Added comprehensive unit tests** covering:
  - Banner content and formatting (headline, reason, CRLF line endings)
  - Optional restart link inclusion based on run ID
  - Graceful handling of missing PTY directory

## Implementation Details
- Uses `O_NONBLOCK` flag when opening PTY devices to prevent a full terminal buffer from stalling the shutdown process
- Ignores individual write failures so one disconnected terminal can't block others
- Implements a 1-second delay after broadcasting to allow ttyd to flush the banner before process exit
- Respects local mode by skipping terminal notifications (where `/dev/pts` would contain the developer's own terminals)

https://claude.ai/code/session_013ed6BKECCQQHroAFX6pCNW