### PR TITLE
Tighten input schemas; skills as textarea, 15-min idle default

### DIFF
--- a/claude-code/.actor/actor.json
+++ b/claude-code/.actor/actor.json
@@ -44,9 +44,9 @@
          "title": "Idle timeout seconds",
          "type": "integer",
          "description": "Automatically shut down after this many seconds of inactivity. Set to 0 to disable. Recommended: set Actor timeout to 0 (infinite) when using this.",
-         "default": 600,
+         "default": 900,
          "editor": "number",
-         "prefill": 600
+         "prefill": 900
        },
        "proxyMappings": {
          "title": "Proxy mappings",

--- a/claude-code/.actor/actor.json
+++ b/claude-code/.actor/actor.json
@@ -31,12 +31,12 @@
         "type": "string",
         "description": "Optional bash script to run on startup for installing packages or setting up the environment.",
         "editor": "textarea",
-        "prefill": "#!/bin/bash\n# Optional bash script run on startup.\n# Uncomment lines below or add your own:\n# apt-get update\n# apt-get install -y curl jq\n# mkdir -p /sandbox/data\n# echo 'export MY_VAR=hello' >> /sandbox/.bashrc"
+        "prefill": "#!/bin/bash\n# Runs on startup. Uncomment or add your own:\n# apt-get update && apt-get install -y jq\n# mkdir -p /sandbox/data"
       },
       "envVars": {
         "title": "Environment variables",
         "type": "string",
-        "description": "Secret environment variables exposed to the sandbox shell, init script, and code execution. Encrypted at rest by Apify and decrypted only at runtime.\n\nAccepts either format:\n- **KEY=VALUE per line** (dotenv-style):\n  ```\n  OPENAI_API_KEY=sk-...\n  MY_VAR=hello\n  ```\n- **JSON object**:\n  ```\n  {\"OPENAI_API_KEY\": \"sk-...\", \"MY_VAR\": \"hello\"}\n  ```",
+        "description": "Secret environment variables exposed to the sandbox shell, init script, and code execution. Encrypted at rest by Apify, decrypted only at runtime. Accepts `KEY=VALUE` per line or a JSON object like `{\"OPENAI_API_KEY\": \"sk-...\", \"MY_VAR\": \"hello\"}`.",
         "editor": "textarea",
         "isSecret": true
       },

--- a/claude-code/.actor/actor.json
+++ b/claude-code/.actor/actor.json
@@ -17,14 +17,11 @@
     "properties": {
        "skills": {
         "title": "Skills",
-        "type": "array",
-        "description": "List of skill packages to install for the AI coding agent. Skills are SKILLS.md files that provide specialized instructions. For more info see https://skills.sh/. Example: apify/agent-skills",
-        "editor": "stringList",
-        "items": {
-          "type": "string"
-        },
-        "default": ["apify/agent-skills"],
-        "prefill": ["apify/agent-skills"]
+        "type": "string",
+        "description": "Skill packages to install for the AI coding agent — SKILLS.md files with specialized instructions (see https://skills.sh/). One skill per line, e.g. `anthropics/skills` (blank lines and `#` comments are ignored), or a JSON array like `[\"apify/agent-skills\", \"anthropics/skills\"]`.",
+        "editor": "textarea",
+        "default": "apify/agent-skills",
+        "prefill": "apify/agent-skills\n# One skill per line, e.g. anthropics/skills"
       },
       "initShellScript": {
         "title": "Initialization script",

--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -25,7 +25,7 @@ This Actor [metamorphs](https://docs.apify.com/platform/actors/development/progr
 
 | Input | Description | Default |
 |-------|-------------|---------|
-| `skills` | Skill packages to install (SKILLS.md files) | `["apify/agent-skills"]` |
+| `skills` | Skill packages to install (SKILLS.md files), one per line or JSON array | `apify/agent-skills` |
 | `initShellScript` | Bash script to run before Claude Code starts | - |
 | `idleTimeoutSeconds` | Shutdown after inactivity | 900 |
 

--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -27,7 +27,7 @@ This Actor [metamorphs](https://docs.apify.com/platform/actors/development/progr
 |-------|-------------|---------|
 | `skills` | Skill packages to install (SKILLS.md files) | `["apify/agent-skills"]` |
 | `initShellScript` | Bash script to run before Claude Code starts | - |
-| `idleTimeoutSeconds` | Shutdown after inactivity | 600 |
+| `idleTimeoutSeconds` | Shutdown after inactivity | 900 |
 
 ## 📚 Skills Support
 

--- a/openclaw/.actor/actor.json
+++ b/openclaw/.actor/actor.json
@@ -31,12 +31,12 @@
         "type": "string",
         "description": "Optional bash script to run on startup for installing packages or setting up the environment.",
         "editor": "textarea",
-        "prefill": "#!/bin/bash\n# Optional bash script run on startup.\n# Uncomment lines below or add your own:\n# apt-get update\n# apt-get install -y curl jq\n# mkdir -p /sandbox/data\n# echo 'export MY_VAR=hello' >> /sandbox/.bashrc"
+        "prefill": "#!/bin/bash\n# Runs on startup. Uncomment or add your own:\n# apt-get update && apt-get install -y jq\n# mkdir -p /sandbox/data"
       },
       "envVars": {
         "title": "Environment variables",
         "type": "string",
-        "description": "Secret environment variables exposed to the sandbox shell, init script, and code execution. Encrypted at rest by Apify and decrypted only at runtime.\n\nAccepts either format:\n- **KEY=VALUE per line** (dotenv-style):\n  ```\n  OPENAI_API_KEY=sk-...\n  MY_VAR=hello\n  ```\n- **JSON object**:\n  ```\n  {\"OPENAI_API_KEY\": \"sk-...\", \"MY_VAR\": \"hello\"}\n  ```",
+        "description": "Secret environment variables exposed to the sandbox shell, init script, and code execution. Encrypted at rest by Apify, decrypted only at runtime. Accepts `KEY=VALUE` per line or a JSON object like `{\"OPENAI_API_KEY\": \"sk-...\", \"MY_VAR\": \"hello\"}`.",
         "editor": "textarea",
         "isSecret": true
       },

--- a/openclaw/.actor/actor.json
+++ b/openclaw/.actor/actor.json
@@ -17,14 +17,11 @@
     "properties": {
        "skills": {
         "title": "Skills",
-        "type": "array",
-        "description": "List of skill packages to install for the AI coding agent. Skills are SKILLS.md files that provide specialized instructions. For more info see https://skills.sh/. Example: apify/agent-skills",
-        "editor": "stringList",
-        "items": {
-          "type": "string"
-        },
-        "default": ["apify/agent-skills"],
-        "prefill": ["apify/agent-skills"]
+        "type": "string",
+        "description": "Skill packages to install for the AI coding agent — SKILLS.md files with specialized instructions (see https://skills.sh/). One skill per line, e.g. `anthropics/skills` (blank lines and `#` comments are ignored), or a JSON array like `[\"apify/agent-skills\", \"anthropics/skills\"]`.",
+        "editor": "textarea",
+        "default": "apify/agent-skills",
+        "prefill": "apify/agent-skills\n# One skill per line, e.g. anthropics/skills"
       },
       "initShellScript": {
         "title": "Initialization script",

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -27,7 +27,7 @@ On startup, it:
 
 | Input | Description | Default |
 |-------|-------------|---------|
-| `skills` | Skill packages to install (SKILLS.md files) | `["apify/agent-skills"]` |
+| `skills` | Skill packages to install (SKILLS.md files), one per line or JSON array | `apify/agent-skills` |
 | `initShellScript` | Bash script to run before OpenClaw starts | - |
 | `idleTimeoutSeconds` | Shutdown after inactivity (0 = disabled) | 0 |
 

--- a/opencode/.actor/actor.json
+++ b/opencode/.actor/actor.json
@@ -31,12 +31,12 @@
         "type": "string",
         "description": "Optional bash script to run on startup for installing packages or setting up the environment.",
         "editor": "textarea",
-        "prefill": "#!/bin/bash\n# Optional bash script run on startup.\n# Uncomment lines below or add your own:\n# apt-get update\n# apt-get install -y curl jq\n# mkdir -p /sandbox/data\n# echo 'export MY_VAR=hello' >> /sandbox/.bashrc"
+        "prefill": "#!/bin/bash\n# Runs on startup. Uncomment or add your own:\n# apt-get update && apt-get install -y jq\n# mkdir -p /sandbox/data"
       },
       "envVars": {
         "title": "Environment variables",
         "type": "string",
-        "description": "Secret environment variables exposed to the sandbox shell, init script, and code execution. Encrypted at rest by Apify and decrypted only at runtime.\n\nAccepts either format:\n- **KEY=VALUE per line** (dotenv-style):\n  ```\n  OPENAI_API_KEY=sk-...\n  MY_VAR=hello\n  ```\n- **JSON object**:\n  ```\n  {\"OPENAI_API_KEY\": \"sk-...\", \"MY_VAR\": \"hello\"}\n  ```",
+        "description": "Secret environment variables exposed to the sandbox shell, init script, and code execution. Encrypted at rest by Apify, decrypted only at runtime. Accepts `KEY=VALUE` per line or a JSON object like `{\"OPENAI_API_KEY\": \"sk-...\", \"MY_VAR\": \"hello\"}`.",
         "editor": "textarea",
         "isSecret": true
       },

--- a/opencode/.actor/actor.json
+++ b/opencode/.actor/actor.json
@@ -17,14 +17,11 @@
     "properties": {
        "skills": {
         "title": "Skills",
-        "type": "array",
-        "description": "List of skill packages to install for the AI coding agent. Skills are SKILLS.md files that provide specialized instructions. For more info see https://skills.sh/. Example: apify/agent-skills",
-        "editor": "stringList",
-        "items": {
-          "type": "string"
-        },
-        "default": ["apify/agent-skills"],
-        "prefill": ["apify/agent-skills"]
+        "type": "string",
+        "description": "Skill packages to install for the AI coding agent — SKILLS.md files with specialized instructions (see https://skills.sh/). One skill per line, e.g. `anthropics/skills` (blank lines and `#` comments are ignored), or a JSON array like `[\"apify/agent-skills\", \"anthropics/skills\"]`.",
+        "editor": "textarea",
+        "default": "apify/agent-skills",
+        "prefill": "apify/agent-skills\n# One skill per line, e.g. anthropics/skills"
       },
       "initShellScript": {
         "title": "Initialization script",

--- a/opencode/.actor/actor.json
+++ b/opencode/.actor/actor.json
@@ -44,9 +44,9 @@
         "title": "Idle timeout seconds",
         "type": "integer",
         "description": "Automatically shut down after this many seconds of inactivity. Set to 0 to disable. Recommended: set Actor timeout to 0 (infinite) when using this.",
-        "default": 600,
+        "default": 900,
         "editor": "number",
-        "prefill": 600
+        "prefill": 900
       }
     },
 

--- a/opencode/README.md
+++ b/opencode/README.md
@@ -24,7 +24,7 @@ This Actor [metamorphs](https://docs.apify.com/platform/actors/development/progr
 
 | Input | Description | Default |
 |-------|-------------|---------|
-| `skills` | Skill packages to install (SKILLS.md files) | `["apify/agent-skills"]` |
+| `skills` | Skill packages to install (SKILLS.md files), one per line or JSON array | `apify/agent-skills` |
 | `initShellScript` | Bash script to run before OpenCode starts | - |
 | `idleTimeoutSeconds` | Shutdown after inactivity | 900 |
 

--- a/opencode/README.md
+++ b/opencode/README.md
@@ -26,7 +26,7 @@ This Actor [metamorphs](https://docs.apify.com/platform/actors/development/progr
 |-------|-------------|---------|
 | `skills` | Skill packages to install (SKILLS.md files) | `["apify/agent-skills"]` |
 | `initShellScript` | Bash script to run before OpenCode starts | - |
-| `idleTimeoutSeconds` | Shutdown after inactivity | 600 |
+| `idleTimeoutSeconds` | Shutdown after inactivity | 900 |
 
 ## 📚 Skills Support
 

--- a/sandbox/.actor/actor.json
+++ b/sandbox/.actor/actor.json
@@ -59,9 +59,9 @@
                 "title": "Idle timeout seconds",
                 "type": "integer",
                 "description": "The container shuts down automatically after this many seconds of inactivity (no requests or shell interaction). Set to 0 to disable. Recommended: set the Actor timeout to 0 (infinite) when using this.",
-                "default": 600,
+                "default": 900,
                 "editor": "number",
-                "prefill": 600
+                "prefill": 900
             },
             "proxyMappings": {
                 "title": "Proxy mappings",

--- a/sandbox/.actor/actor.json
+++ b/sandbox/.actor/actor.json
@@ -30,23 +30,23 @@
             "nodeDependencies": {
                 "title": "Node.js dependencies",
                 "type": "string",
-                "description": "npm packages to install for JavaScript and TypeScript code execution (/sandbox/js-ts).\n\nAccepts either format:\n- **One `package@version` per line** (npm CLI style):\n  ```\n  zod@^3.0\n  axios@latest\n  lodash\n  ```\n  Lines without `@version` default to `latest`. Blank lines and `#` comments are ignored. Scoped packages like `@types/node@^20` are supported.\n- **JSON object** (package.json `dependencies` style):\n  ```\n  {\"zod\": \"^3.0\", \"axios\": \"latest\"}\n  ```",
+                "description": "npm packages for JavaScript/TypeScript code execution (/sandbox/js-ts). One `package@version` per line (omit `@version` for `latest`; blank lines and `#` comments are ignored), or a JSON object like `{\"zod\": \"^3.0\", \"axios\": \"latest\"}`.",
                 "editor": "textarea",
-                "prefill": "# One package@version per line. Omit @version for latest.\n# Uncomment lines below or add your own:\n# zod@^3.0\n# axios@latest\n# lodash\n# @types/node@^20\n#\n# Or use JSON object format (package.json dependencies style):\n# {\"zod\": \"^3.0\", \"axios\": \"latest\"}"
+                "prefill": "# One package@version per line (omit @version for latest):\n# zod@^3.0\n# axios"
             },
             "pythonRequirementsTxt": {
                 "title": "Python requirements",
                 "type": "string",
-                "description": "Python requirements in requirements.txt format for Python code execution (/sandbox/py). Paste your dependencies one per line. Example:\n requests==2.31.0\npandas>=2.0.0",
+                "description": "Python packages for Python code execution (/sandbox/py), in requirements.txt format — one package per line.",
                 "editor": "textarea",
-                "prefill": "# One package per line, in requirements.txt format.\n# Uncomment lines below or add your own:\n# requests==2.31.0\n# pandas>=2.0.0\n# numpy\n# beautifulsoup4>=4.12"
+                "prefill": "# One package per line (requirements.txt format):\n# requests==2.31.0\n# pandas"
             },
             "initShellScript": {
                 "title": "Initialization script",
                 "type": "string",
-                "description": "Optional bash script to customize the sandbox environment. Runs after library installation in /sandbox directory. Use for installing system packages, creating directories, or other setup tasks.",
+                "description": "Optional bash script run on startup, after dependencies are installed. Use it to install system packages, create directories, or set up the environment.",
                 "editor": "textarea",
-                "prefill": "#!/bin/bash\n# Optional bash script run on startup, after dependencies are installed.\n# Uncomment lines below or add your own:\n# apt-get update\n# apt-get install -y curl jq\n# mkdir -p /sandbox/data\n# echo 'export MY_VAR=hello' >> /sandbox/.bashrc"
+                "prefill": "#!/bin/bash\n# Runs on startup. Uncomment or add your own:\n# apt-get update && apt-get install -y jq\n# mkdir -p /sandbox/data"
             },
             "envVars": {
                 "title": "Environment variables",
@@ -58,7 +58,7 @@
             "idleTimeoutSeconds": {
                 "title": "Idle timeout seconds",
                 "type": "integer",
-                "description": "The container will automatically shut down after this period of inactivity (no requests, no shell interaction). Set to 0 to disable. Recommended to set Actor execution timeout to 0 (infinite) when using this.",
+                "description": "The container shuts down automatically after this many seconds of inactivity (no requests or shell interaction). Set to 0 to disable. Recommended: set the Actor timeout to 0 (infinite) when using this.",
                 "default": 600,
                 "editor": "number",
                 "prefill": 600
@@ -90,7 +90,7 @@
             "mcpConnections": {
                 "title": "MCP Connections",
                 "type": "array",
-                "description": "MCP Connectors the sandbox can call on your behalf — for example Slack, Notion, GitHub, or any other MCP server you have authorized in Settings > API & Integrations > MCP Connectors. At runtime the platform injects your credentials and exposes each Connector as a proxy at `${APIFY_MCP_PROXY_URL}/<connectorId>`. The sandbox writes the full list to `/sandbox/mcp.json` on startup so tools like `mcpc connect` can pick them up immediately.",
+                "description": "MCP Connectors the sandbox can call on your behalf (Slack, Notion, GitHub, or any MCP server authorized in Settings > API & Integrations > MCP Connectors). At runtime the platform injects your credentials, exposes each as a proxy at `${APIFY_MCP_PROXY_URL}/<connectorId>`, and writes the list to `/sandbox/mcp.json` so tools like `mcpc connect` pick them up immediately.",
                 "resourceType": "mcpConnector",
                 "mcpServers": [{ "url": "*" }],
                 "editor": "resourcePicker",

--- a/sandbox/.actor/actor.json
+++ b/sandbox/.actor/actor.json
@@ -18,14 +18,11 @@
         "properties": {
             "skills": {
                 "title": "Skills",
-                "type": "array",
-                "description": "List of skill packages to install for the AI coding agent. Skills are SKILLS.md files that provide specialized instructions. For more info see https://skills.sh/. Example: apify/agent-skills",
-                "editor": "stringList",
-                "items": {
-                    "type": "string"
-                },
-                "default": ["apify/agent-skills"],
-                "prefill": ["apify/agent-skills"]
+                "type": "string",
+                "description": "Skill packages to install for the AI coding agent — SKILLS.md files with specialized instructions (see https://skills.sh/). One skill per line, e.g. `anthropics/skills` (blank lines and `#` comments are ignored), or a JSON array like `[\"apify/agent-skills\", \"anthropics/skills\"]`.",
+                "editor": "textarea",
+                "default": "apify/agent-skills",
+                "prefill": "apify/agent-skills\n# One skill per line, e.g. anthropics/skills"
             },
             "nodeDependencies": {
                 "title": "Node.js dependencies",

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -340,7 +340,7 @@ Mappings can also be modified by writing JSON to `/sandbox/.proxy-mappings.json`
 ## Configuration
 
 - **Memory & timeout:** Configure run options to set memory allocation and execution timeout
-- **Idle timeout:** The container automatically shuts down after a period of inactivity (default: 10 minutes). Activity includes HTTP requests and shell interaction. You can adjust this via the `idleTimeoutSeconds` input.
+- **Idle timeout:** The container automatically shuts down after a period of inactivity (default: 15 minutes). Activity includes HTTP requests and shell interaction. You can adjust this via the `idleTimeoutSeconds` input.
 - **Recommendation:** For cost efficiency, set the standard Actor **Execution Timeout to 0 (infinite)** in the Apify Console. The internal idle logic will then manage the lifecycle based on your usage.
 - **Request timeout:** All requests to the Actor have a 5-minute timeout ceiling. All operations (code execution, commands, file operations) must complete within this time limit. The `timeout` parameter in requests cannot exceed this 5-minute window
 - **Check logs:** Open the Actor run log console to view connection details and operation output

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -416,8 +416,8 @@ mkdir -p /sandbox/custom-data && chmod 755 /sandbox/custom-data
 
 Install skill packages that provide specialized instructions for AI coding agents. Skills are SKILLS.md files that enhance agent capabilities.
 
-- Specify skills via the "Skills" input (array of package names)
-- Example: `["apify/agent-skills"]`
+- Specify skills via the "Skills" input — one package per line (e.g. `anthropics/skills`), or a JSON array
+- Example: `apify/agent-skills`
 - Skills are installed globally during Actor startup
 - For more info see [skills.sh](https://skills.sh/)
 

--- a/sandbox/src/env-vars.ts
+++ b/sandbox/src/env-vars.ts
@@ -1,24 +1,20 @@
 import { log } from 'apify';
 
+import { isFlatJsonObject, safeParseJson } from './safe-json.js';
+
 const VALID_KEY = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 const parseJsonObject = (raw: string): Record<string, string> => {
-    let parsed: unknown;
-    try {
-        parsed = JSON.parse(raw);
-    } catch (error) {
-        const err = error as Error;
-        log.warning('envVars: failed to parse JSON input, ignoring', { error: err.message });
-        return {};
-    }
-
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-        log.warning('envVars: JSON must be a flat object of string keys and string values');
-        return {};
-    }
+    const parsed = safeParseJson(
+        raw,
+        'envVars',
+        isFlatJsonObject,
+        'JSON must be a flat object of string keys and string values',
+    );
+    if (!parsed) return {};
 
     const out: Record<string, string> = {};
-    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+    for (const [key, value] of Object.entries(parsed)) {
         if (!VALID_KEY.test(key)) {
             log.warning('envVars: skipping invalid key', { key });
             continue;

--- a/sandbox/src/main.ts
+++ b/sandbox/src/main.ts
@@ -38,6 +38,7 @@ import {
     removeProxyMapping,
     onMappingsChange,
 } from './proxy-config.js';
+import { parseSkills } from './skills.js';
 import { getLandingPageHTML, getLLMsMarkdown } from './templates/landing.js';
 import { SANDBOX_BASHRC, WELCOME_SCRIPT } from './templates/shell.js';
 import type { ActorInput, ProxyMapping } from './types.js';
@@ -71,9 +72,11 @@ const userEnvVars = parseEnvVars(input?.envVars);
 setUserEnvVars(userEnvVars);
 
 const nodeDependencies = parseNodeDependencies(input?.nodeDependencies);
+const skills = parseSkills(input?.skills);
 
 log.info('Actor input retrieved', {
     mode: isLocalMode ? 'local' : 'production',
+    hasSkills: skills.length > 0,
     hasNodeDependencies: Object.keys(nodeDependencies).length > 0,
     hasPythonRequirements: !!input?.pythonRequirementsTxt?.trim().length,
     hasInitScript: !!input?.initShellScript?.trim().length,
@@ -112,7 +115,7 @@ if (restoredFromMigration) {
 } else {
     log.info('Setting up execution environment...');
     setupResult = await setupExecutionEnvironment({
-        skills: input?.skills,
+        skills,
         nodeDependencies,
         pythonRequirementsTxt: input?.pythonRequirementsTxt,
     });

--- a/sandbox/src/main.ts
+++ b/sandbox/src/main.ts
@@ -1237,7 +1237,7 @@ server.listen(port, () => {
     console.log('=====================================\n');
 
     // Start idle timeout check
-    const idleTimeoutSecs = input?.idleTimeoutSeconds ?? 600;
+    const idleTimeoutSecs = input?.idleTimeoutSeconds ?? 900;
     if (idleTimeoutSecs > 0) {
         log.info(`Idle timeout monitor started (${idleTimeoutSecs}s)`);
         setInterval(async () => {

--- a/sandbox/src/node-deps.ts
+++ b/sandbox/src/node-deps.ts
@@ -1,27 +1,23 @@
 import { log } from 'apify';
 
+import { isFlatJsonObject, safeParseJson } from './safe-json.js';
+
 /**
  * Parse a `{ "package": "version" }` object. Coerces numeric versions to
  * strings and null/empty values to `latest`; malformed JSON degrades to `{}`
  * with a warning so a single bad character does not abort the run.
  */
 const parseJsonObject = (raw: string): Record<string, string> => {
-    let parsed: unknown;
-    try {
-        parsed = JSON.parse(raw);
-    } catch (error) {
-        const err = error as Error;
-        log.warning('nodeDependencies: failed to parse JSON input, ignoring', { error: err.message });
-        return {};
-    }
-
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-        log.warning('nodeDependencies: JSON must be a flat object of package names to version strings');
-        return {};
-    }
+    const parsed = safeParseJson(
+        raw,
+        'nodeDependencies',
+        isFlatJsonObject,
+        'JSON must be a flat object of package names to version strings',
+    );
+    if (!parsed) return {};
 
     const out: Record<string, string> = {};
-    for (const [name, value] of Object.entries(parsed as Record<string, unknown>)) {
+    for (const [name, value] of Object.entries(parsed)) {
         const pkg = name.trim();
         if (!pkg) continue;
         if (value === null || value === undefined || value === '') {

--- a/sandbox/src/safe-json.ts
+++ b/sandbox/src/safe-json.ts
@@ -1,0 +1,34 @@
+import { log } from 'apify';
+
+/** Type guard for a non-null, non-array JSON object. */
+export const isFlatJsonObject = (value: unknown): value is Record<string, unknown> =>
+    !!value && typeof value === 'object' && !Array.isArray(value);
+
+/**
+ * Safely parse user-supplied JSON and verify it matches an expected shape.
+ *
+ * Returns the parsed value on success, or `null` if `JSON.parse` threw or the
+ * `isValid` predicate rejected the result. Both failure modes log a warning
+ * labeled with `fieldName` so callers can degrade to an empty result without
+ * aborting the run.
+ */
+export const safeParseJson = <T>(
+    raw: string,
+    fieldName: string,
+    isValid: (parsed: unknown) => parsed is T,
+    shapeDescription: string,
+): T | null => {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch (error) {
+        const err = error as Error;
+        log.warning(`${fieldName}: failed to parse JSON input, ignoring`, { error: err.message });
+        return null;
+    }
+    if (!isValid(parsed)) {
+        log.warning(`${fieldName}: ${shapeDescription}`);
+        return null;
+    }
+    return parsed;
+};

--- a/sandbox/src/skills.ts
+++ b/sandbox/src/skills.ts
@@ -1,0 +1,72 @@
+import { log } from 'apify';
+
+/**
+ * Trim entries, drop blanks and non-strings, and de-duplicate while preserving
+ * the original order.
+ */
+const cleanList = (values: unknown[]): string[] => {
+    const out: string[] = [];
+    const seen = new Set<string>();
+    for (const value of values) {
+        if (typeof value !== 'string') {
+            log.warning('skills: skipping non-string entry');
+            continue;
+        }
+        const skill = value.trim();
+        if (!skill || seen.has(skill)) continue;
+        seen.add(skill);
+        out.push(skill);
+    }
+    return out;
+};
+
+/**
+ * Parse a JSON array of skill name strings. Malformed JSON or a non-array value
+ * degrades to `[]` with a warning so a single bad character does not abort the run.
+ */
+const parseJsonArray = (raw: string): string[] => {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch (error) {
+        const err = error as Error;
+        log.warning('skills: failed to parse JSON input, ignoring', { error: err.message });
+        return [];
+    }
+
+    if (!Array.isArray(parsed)) {
+        log.warning('skills: JSON must be an array of skill name strings');
+        return [];
+    }
+    return cleanList(parsed);
+};
+
+const parseLines = (raw: string): string[] => {
+    const out: string[] = [];
+    for (const rawLine of raw.split(/\r?\n/)) {
+        const line = rawLine.trim();
+        if (!line || line.startsWith('#')) continue;
+        out.push(line);
+    }
+    return out;
+};
+
+/**
+ * Parse the user-supplied `skills` input into a de-duplicated list of skill
+ * identifiers for `installSkills`. Accepts either:
+ *  - one skill per line (e.g. `anthropics/skills`; blank lines and `#` comments ignored), or
+ *  - a JSON array of skill name strings (input starting with `[` or `{` is parsed
+ *    as JSON; any non-array JSON yields no skills).
+ *
+ * Also accepts an actual string array, which task inputs saved while `skills`
+ * was a `stringList` (and programmatic callers) may still send.
+ */
+export const parseSkills = (raw: string | string[] | undefined | null): string[] => {
+    if (!raw) return [];
+    if (Array.isArray(raw)) return cleanList(raw);
+
+    const trimmed = raw.trim();
+    if (!trimmed) return [];
+    const looksLikeJson = trimmed.startsWith('[') || trimmed.startsWith('{');
+    return looksLikeJson ? parseJsonArray(trimmed) : cleanList(parseLines(trimmed));
+};

--- a/sandbox/src/skills.ts
+++ b/sandbox/src/skills.ts
@@ -1,5 +1,7 @@
 import { log } from 'apify';
 
+import { safeParseJson } from './safe-json.js';
+
 /**
  * Trim entries, drop blanks and non-strings, and de-duplicate while preserving
  * the original order.
@@ -20,25 +22,9 @@ const cleanList = (values: unknown[]): string[] => {
     return out;
 };
 
-/**
- * Parse a JSON array of skill name strings. Malformed JSON or a non-array value
- * degrades to `[]` with a warning so a single bad character does not abort the run.
- */
 const parseJsonArray = (raw: string): string[] => {
-    let parsed: unknown;
-    try {
-        parsed = JSON.parse(raw);
-    } catch (error) {
-        const err = error as Error;
-        log.warning('skills: failed to parse JSON input, ignoring', { error: err.message });
-        return [];
-    }
-
-    if (!Array.isArray(parsed)) {
-        log.warning('skills: JSON must be an array of skill name strings');
-        return [];
-    }
-    return cleanList(parsed);
+    const parsed = safeParseJson(raw, 'skills', Array.isArray, 'JSON must be an array of skill name strings');
+    return parsed ? cleanList(parsed) : [];
 };
 
 const parseLines = (raw: string): string[] => {

--- a/sandbox/src/types.ts
+++ b/sandbox/src/types.ts
@@ -14,12 +14,11 @@ export interface ProxyMapping {
 
 export interface ActorInput {
     /**
-     * Skill packages to install for the AI coding agent
-     * Skills are SKILL.md files that provide specialized instructions
-     * Format: array of skill package names or URLs
-     * Example: ["apify/agent-skills"]
+     * Skill packages to install for the AI coding agent (SKILLS.md files).
+     * Accepts one skill per line (e.g. `anthropics/skills`; blank lines and
+     * `#` comments ignored) or a JSON array of skill name strings.
      */
-    skills?: string[];
+    skills?: string;
 
     /**
      * Node.js dependencies for JavaScript and TypeScript code execution.

--- a/sandbox/src/types.ts
+++ b/sandbox/src/types.ts
@@ -51,7 +51,7 @@ export interface ActorInput {
     /**
      * Graceful shutdown timeout in seconds if no activity is detected.
      * Activity includes HTTP requests and shell interaction.
-     * @default 600 (10 minutes)
+     * @default 900 (15 minutes)
      */
     idleTimeoutSeconds?: number;
 

--- a/sandbox/tests/unit/safe-json.test.ts
+++ b/sandbox/tests/unit/safe-json.test.ts
@@ -1,0 +1,108 @@
+/* eslint-disable @typescript-eslint/no-floating-promises -- node:test's describe/it return promises by design */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { isFlatJsonObject, safeParseJson } from '../../src/safe-json.js';
+
+describe('isFlatJsonObject', () => {
+    it('returns true for an empty object', () => {
+        assert.equal(isFlatJsonObject({}), true);
+    });
+
+    it('returns true for a non-empty object', () => {
+        assert.equal(isFlatJsonObject({ foo: 1 }), true);
+    });
+
+    it('returns true for an object with nested values (only the top-level is checked)', () => {
+        assert.equal(isFlatJsonObject({ foo: { bar: 1 } }), true);
+    });
+
+    it('returns false for an empty array', () => {
+        assert.equal(isFlatJsonObject([]), false);
+    });
+
+    it('returns false for a non-empty array', () => {
+        assert.equal(isFlatJsonObject([1, 2, 3]), false);
+    });
+
+    it('returns false for null', () => {
+        assert.equal(isFlatJsonObject(null), false);
+    });
+
+    it('returns false for primitive values', () => {
+        assert.equal(isFlatJsonObject('string'), false);
+        assert.equal(isFlatJsonObject(42), false);
+        assert.equal(isFlatJsonObject(true), false);
+        assert.equal(isFlatJsonObject(undefined), false);
+    });
+});
+
+describe('safeParseJson', () => {
+    const shapeMsg = 'must be a flat object';
+    const arrayMsg = 'must be an array';
+
+    describe('with isFlatJsonObject predicate', () => {
+        it('returns the parsed object on success', () => {
+            assert.deepEqual(safeParseJson('{"foo": "bar"}', 'test', isFlatJsonObject, shapeMsg), { foo: 'bar' });
+        });
+
+        it('parses a pretty-printed object', () => {
+            const input = '{\n  "foo": "bar",\n  "baz": 1\n}';
+            assert.deepEqual(safeParseJson(input, 'test', isFlatJsonObject, shapeMsg), { foo: 'bar', baz: 1 });
+        });
+
+        it('returns null for an array', () => {
+            assert.equal(safeParseJson('["foo"]', 'test', isFlatJsonObject, shapeMsg), null);
+        });
+
+        it('returns null for a JSON null literal', () => {
+            assert.equal(safeParseJson('null', 'test', isFlatJsonObject, shapeMsg), null);
+        });
+
+        it('returns null for a primitive value', () => {
+            assert.equal(safeParseJson('42', 'test', isFlatJsonObject, shapeMsg), null);
+            assert.equal(safeParseJson('"hello"', 'test', isFlatJsonObject, shapeMsg), null);
+        });
+    });
+
+    describe('with Array.isArray predicate', () => {
+        it('returns the parsed array on success', () => {
+            assert.deepEqual(safeParseJson('["a", "b"]', 'test', Array.isArray, arrayMsg), ['a', 'b']);
+        });
+
+        it('parses an empty array', () => {
+            assert.deepEqual(safeParseJson('[]', 'test', Array.isArray, arrayMsg), []);
+        });
+
+        it('returns null for an object', () => {
+            assert.equal(safeParseJson('{"foo": 1}', 'test', Array.isArray, arrayMsg), null);
+        });
+    });
+
+    describe('malformed JSON', () => {
+        it('returns null for syntactically invalid JSON', () => {
+            assert.equal(safeParseJson('{not valid json', 'test', isFlatJsonObject, shapeMsg), null);
+        });
+
+        it('returns null for an unterminated string', () => {
+            assert.equal(safeParseJson('"unterminated', 'test', isFlatJsonObject, shapeMsg), null);
+        });
+
+        it('returns null for empty input', () => {
+            assert.equal(safeParseJson('', 'test', isFlatJsonObject, shapeMsg), null);
+        });
+
+        it('returns null for whitespace-only input', () => {
+            assert.equal(safeParseJson('   ', 'test', isFlatJsonObject, shapeMsg), null);
+        });
+    });
+
+    describe('custom predicates', () => {
+        it('honors a stricter type guard', () => {
+            const isStringArray = (v: unknown): v is string[] =>
+                Array.isArray(v) && v.every((x) => typeof x === 'string');
+            assert.deepEqual(safeParseJson('["a", "b"]', 'test', isStringArray, 'string[]'), ['a', 'b']);
+            assert.equal(safeParseJson('[1, 2]', 'test', isStringArray, 'string[]'), null);
+        });
+    });
+});

--- a/sandbox/tests/unit/skills.test.ts
+++ b/sandbox/tests/unit/skills.test.ts
@@ -1,0 +1,119 @@
+/* eslint-disable @typescript-eslint/no-floating-promises -- node:test's describe/it return promises by design */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { parseSkills } from '../../src/skills.js';
+
+describe('parseSkills', () => {
+    describe('empty input', () => {
+        it('returns [] for undefined', () => {
+            assert.deepEqual(parseSkills(undefined), []);
+        });
+
+        it('returns [] for null', () => {
+            assert.deepEqual(parseSkills(null), []);
+        });
+
+        it('returns [] for empty string', () => {
+            assert.deepEqual(parseSkills(''), []);
+        });
+
+        it('returns [] for whitespace-only input', () => {
+            assert.deepEqual(parseSkills('   \n  \t  \n'), []);
+        });
+
+        it('returns [] for an empty array', () => {
+            assert.deepEqual(parseSkills([]), []);
+        });
+    });
+
+    describe('line format', () => {
+        it('parses a single skill', () => {
+            assert.deepEqual(parseSkills('apify/agent-skills'), ['apify/agent-skills']);
+        });
+
+        it('parses multiple skills, one per line', () => {
+            const input = 'apify/agent-skills\nanthropics/skills';
+            assert.deepEqual(parseSkills(input), ['apify/agent-skills', 'anthropics/skills']);
+        });
+
+        it('ignores blank lines', () => {
+            const input = '\n\napify/agent-skills\n\n\nanthropics/skills\n\n';
+            assert.deepEqual(parseSkills(input), ['apify/agent-skills', 'anthropics/skills']);
+        });
+
+        it('ignores # comment lines', () => {
+            const input = '# my skills\napify/agent-skills\n# another comment\nanthropics/skills';
+            assert.deepEqual(parseSkills(input), ['apify/agent-skills', 'anthropics/skills']);
+        });
+
+        it('trims whitespace around skill names', () => {
+            const input = '   apify/agent-skills   \n\t anthropics/skills\t';
+            assert.deepEqual(parseSkills(input), ['apify/agent-skills', 'anthropics/skills']);
+        });
+
+        it('handles \\r\\n line endings', () => {
+            assert.deepEqual(parseSkills('apify/agent-skills\r\nanthropics/skills'), [
+                'apify/agent-skills',
+                'anthropics/skills',
+            ]);
+        });
+
+        it('de-duplicates while preserving order', () => {
+            const input = 'apify/agent-skills\nanthropics/skills\napify/agent-skills';
+            assert.deepEqual(parseSkills(input), ['apify/agent-skills', 'anthropics/skills']);
+        });
+    });
+
+    describe('JSON array format', () => {
+        it('parses a JSON array', () => {
+            const input = '["apify/agent-skills", "anthropics/skills"]';
+            assert.deepEqual(parseSkills(input), ['apify/agent-skills', 'anthropics/skills']);
+        });
+
+        it('parses a JSON array with leading whitespace', () => {
+            assert.deepEqual(parseSkills('   ["apify/agent-skills"]   '), ['apify/agent-skills']);
+        });
+
+        it('trims and drops empty entries', () => {
+            assert.deepEqual(parseSkills('[" apify/agent-skills ", ""]'), ['apify/agent-skills']);
+        });
+
+        it('skips non-string entries', () => {
+            assert.deepEqual(parseSkills('["apify/agent-skills", 42, null, {"x": 1}]'), ['apify/agent-skills']);
+        });
+
+        it('de-duplicates entries', () => {
+            assert.deepEqual(parseSkills('["apify/agent-skills", "apify/agent-skills"]'), ['apify/agent-skills']);
+        });
+
+        it('returns [] for malformed JSON', () => {
+            assert.deepEqual(parseSkills('[not valid json'), []);
+        });
+
+        it('returns [] for a non-array JSON value', () => {
+            assert.deepEqual(parseSkills('{"skills": ["apify/agent-skills"]}'), []);
+        });
+
+        it('parses an empty JSON array as []', () => {
+            assert.deepEqual(parseSkills('[]'), []);
+        });
+    });
+
+    describe('array input (legacy stringList)', () => {
+        it('cleans and de-duplicates a string array', () => {
+            const input = [' apify/agent-skills ', 'anthropics/skills', 'apify/agent-skills', ''];
+            assert.deepEqual(parseSkills(input), ['apify/agent-skills', 'anthropics/skills']);
+        });
+    });
+
+    describe('format detection', () => {
+        it('treats input starting with [ as JSON', () => {
+            assert.deepEqual(parseSkills('["apify/agent-skills"]'), ['apify/agent-skills']);
+        });
+
+        it('treats input not starting with [ as line format', () => {
+            assert.deepEqual(parseSkills('apify/agent-skills'), ['apify/agent-skills']);
+        });
+    });
+});


### PR DESCRIPTION
- Trim the verbose prefill templates and field descriptions added in #39 down to a short hint plus one or two examples.
- Switch `skills` from a `stringList` to a textarea — one skill per line (with `#` comments) or a JSON array — matching `nodeDependencies` and `pythonRequirementsTxt`.
- Raise the default `idleTimeoutSeconds` from 600s to 900s (15 min) so brief pauses don't kill long-running sessions; openclaw stays at 0 (disabled).
- Extract a shared `safeParseJson` helper now that three input parsers use the same try/parse/warn/shape-check scaffolding.