### PR TITLE
Move shell terminal to root, docs to /info endpoint

### DIFF
--- a/sandbox/.actor/actor.json
+++ b/sandbox/.actor/actor.json
@@ -110,8 +110,13 @@
         "properties": {
             "url": {
                 "type": "string",
-                "title": "Main page",
+                "title": "Live shell",
                 "template": "{{run.containerUrl}}"
+            },
+            "docsUrl": {
+                "type": "string",
+                "title": "Docs & API",
+                "template": "{{links.containerUrl}}/info"
             },
             "shellUrl": {
                 "type": "string",

--- a/sandbox/src/main.ts
+++ b/sandbox/src/main.ts
@@ -39,6 +39,7 @@ import {
     onMappingsChange,
 } from './proxy-config.js';
 import { getLandingPageHTML, getLLMsMarkdown } from './templates/landing.js';
+import { getShellLiveViewHTML } from './templates/live-view.js';
 import { SANDBOX_BASHRC, WELCOME_SCRIPT } from './templates/shell.js';
 import type { ActorInput, ProxyMapping } from './types.js';
 
@@ -634,8 +635,16 @@ app.delete('/fs/*path', async (req: Request, res: Response) => {
 // Middleware for JSON parsing (applied to routes below)
 app.use(express.json({ limit: '50mb' }));
 
-// Landing page endpoint
+// Root serves the live shell terminal. Apify's run Live View always loads the
+// container root, so embedding /shell/ here surfaces the interactive terminal
+// directly in the run console.
 app.get('/', (_req: Request, res: Response) => {
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.send(getShellLiveViewHTML());
+});
+
+// Docs / API landing page (moved off `/` so the Live View can show the shell).
+app.get('/info', (_req: Request, res: Response) => {
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
     res.send(
         getLandingPageHTML({
@@ -1187,13 +1196,17 @@ server.listen(port, () => {
     console.log('🚀 Apify AI Sandbox Started');
     console.log('=====================================\n');
 
-    console.log('🏠 Landing page (open first):');
+    console.log('🖥️  Live shell (shown in the run Live View):');
     console.log(`   GET ${serverUrl}/`);
+    console.log('       Interactive shell terminal, embedded\n');
+
+    console.log('🏠 Docs & endpoints page:');
+    console.log(`   GET ${serverUrl}/info`);
     console.log('       Connection details, quick links, and endpoint URLs\n');
 
     // Shell terminal endpoint
     console.log(`   GET ${serverUrl}/shell/`);
-    console.log(`       Interactive shell terminal\n`);
+    console.log(`       Raw interactive shell terminal\n`);
 
     // MCP Server URL
     console.log('📡 MCP Server Endpoint:');

--- a/sandbox/src/templates/landing.ejs
+++ b/sandbox/src/templates/landing.ejs
@@ -179,7 +179,8 @@
                 </div>
             </div>
             <ul class="list">
-                <li><strong>Landing page</strong>: <a href="<%= serverUrl %>/"><%= serverUrl %>/</a></li>
+                <li><strong>Live shell (home)</strong>: <a href="<%= serverUrl %>/"><%= serverUrl %>/</a></li>
+                <li><strong>Docs page</strong>: <a href="<%= serverUrl %>/info"><%= serverUrl %>/info</a></li>
                 <li><strong>Shell terminal</strong>: <a href="<%= serverUrl %>/shell/"><%= serverUrl %>/shell/</a></li>
                 <li><strong>Health check</strong>: <a href="<%= serverUrl %>/health"><%= serverUrl %>/health</a></li>
                 <li><strong>MCP endpoint</strong>: <a href="<%= serverUrl %>/mcp"><%= serverUrl %>/mcp</a></li>

--- a/sandbox/src/templates/live-view.ts
+++ b/sandbox/src/templates/live-view.ts
@@ -1,0 +1,25 @@
+/**
+ * Full-page wrapper that embeds the interactive shell terminal in an iframe.
+ *
+ * Served at `/` so the Apify run's Live View — which always loads the container
+ * root — shows the live terminal directly in the run console.
+ */
+export function getShellLiveViewHTML(): string {
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sandbox | Shell</title>
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <style>
+        html, body { margin: 0; padding: 0; height: 100%; background: #000; }
+        iframe { border: 0; display: block; width: 100%; height: 100%; }
+    </style>
+</head>
+<body>
+    <iframe src="/shell/" title="Interactive shell" allow="clipboard-read; clipboard-write"></iframe>
+</body>
+</html>
+`;
+}

--- a/sandbox/src/templates/shell.ts
+++ b/sandbox/src/templates/shell.ts
@@ -59,7 +59,7 @@ fi
 echo ""
 echo -e "\${BLUE}Documentation:\${NC}"
 if [ -n "\$ACTOR_WEB_SERVER_URL" ]; then
-    echo -e "  - Actor page:        \$ACTOR_WEB_SERVER_URL"
+    echo -e "  - Docs & API:        \$ACTOR_WEB_SERVER_URL/info"
 fi
 if [ -n "\$ACTOR_RUN_ID" ]; then
     echo -e "  - Run details:       https://console.apify.com/view/runs/\$ACTOR_RUN_ID"


### PR DESCRIPTION
## Summary
Restructures the sandbox web server routing to surface the interactive shell terminal at the root endpoint (`/`), making it the default Live View for Apify runs. The documentation and API landing page has been moved to `/info`.

## Key Changes
- **New live-view template**: Created `live-view.ts` with `getShellLiveViewHTML()` that wraps the shell terminal in a full-page iframe, optimized for Apify's Live View display
- **Root endpoint (`/`)**: Now serves the embedded shell terminal instead of the landing page, since Apify's Live View always loads the container root
- **Docs endpoint (`/info`)**: Moved the landing page (connection details, quick links, endpoint URLs) from `/` to `/info`
- **Updated actor.json**: Added `docsUrl` link pointing to `/info` and renamed the main `url` title from "Main page" to "Live shell"
- **Updated documentation**: Modified shell welcome script and landing page template to reflect the new URL structure and clarify endpoint purposes
- **Updated startup logs**: Changed console output to highlight the live shell at root and the docs page at `/info`

## Implementation Details
- The live-view HTML is a minimal wrapper with full-height iframe styling and black background, designed to seamlessly embed the shell terminal
- The iframe includes `allow="clipboard-read; clipboard-write"` permissions to support terminal clipboard operations
- All references to the old landing page URL have been updated throughout the codebase to point to `/info`

https://claude.ai/code/session_01YJZHMbJgwvYNc5WRf8TJ6v