### PR TITLE
Fix shell launch restart loop with persistent interactive shell

### DIFF
--- a/claude-code/.actor/actor.json
+++ b/claude-code/.actor/actor.json
@@ -84,7 +84,7 @@
       "url": {
         "type": "string",
         "title": "Main page",
-        "template": "{{run.containerUrl}}/shell?arg=-c&arg=source%20/app/sandbox_bashrc%3B%20claude"
+        "template": "{{run.containerUrl}}/shell?launch=claude"
       }
     }
   },

--- a/openclaw/.actor/actor.json
+++ b/openclaw/.actor/actor.json
@@ -60,7 +60,7 @@
       "url": {
         "type": "string",
         "title": "Main page",
-        "template": "{{run.containerUrl}}/shell?arg=-c&arg=source%20/app/sandbox_bashrc%3B%20openclaw%20tui"
+        "template": "{{run.containerUrl}}/shell?launch=openclaw%20tui"
       }
     }
   },

--- a/openclaw/src/main.ts
+++ b/openclaw/src/main.ts
@@ -40,6 +40,13 @@ cat > ~/.openclaw/openclaw.json << 'CLAWEOF'
       "workspace": "~/.openclaw/workspace"
     }
   },
+  "tools": {
+    "exec": {
+      "host": "gateway",
+      "security": "full",
+      "ask": "off"
+    }
+  },
   "models": {
     "mode": "merge",
     "providers": {
@@ -73,6 +80,16 @@ openclaw onboard \\
   --gateway-port 18789 \\
   --skip-daemon \\
   --skip-health
+# Auto-approve all tool actions (YOLO) — safe inside the sandbox. The effective
+# policy is the stricter of two layers, so open both: the requested policy in
+# openclaw.json (tools.exec, set above) and the host-local approvals file below.
+openclaw exec-policy preset yolo || true
+cat > ~/.openclaw/exec-approvals.json << 'APPROVEEOF'
+{
+  "version": 1,
+  "defaults": { "security": "full", "ask": "off", "askFallback": "full" }
+}
+APPROVEEOF
 nohup openclaw gateway run --bind loopback --port 18789 > /tmp/openclaw-gateway.log 2>&1 &
 sleep 3
 echo "OpenClaw started: http://127.0.0.1:18789/openclaw/"`;

--- a/opencode/.actor/actor.json
+++ b/opencode/.actor/actor.json
@@ -60,7 +60,7 @@
       "url": {
         "type": "string",
         "title": "Main page",
-        "template": "{{run.containerUrl}}/shell?arg=-c&arg=source%20/app/sandbox_bashrc%3B%20opencode"
+        "template": "{{run.containerUrl}}/shell?launch=opencode"
       }
     }
   },

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -132,9 +132,15 @@ ENV IS_SANDBOX=1
 # Set Claude Code max output tokens to 64000
 ENV CLAUDE_CODE_MAX_OUTPUT_TOKENS=128000
 
-# Configure Claude Code to bypass permissions
-RUN mkdir -p /root/.claude && \
-    echo '{"permissions": {"defaultMode": "bypassPermissions"}}' > /root/.claude/settings.json
+# Pre-accept Claude Code's first-run onboarding so the CLI starts immediately.
+# Permission prompts are bypassed via --dangerously-skip-permissions in the shell
+# wrapper (see SANDBOX_BASHRC); settings.json bypass mode triggers a blocking
+# confirmation dialog, so we deliberately don't set it here.
+RUN echo '{"hasCompletedOnboarding": true}' > /root/.claude.json
+
+# Configure Codex CLI to auto-approve everything — safe inside the sandbox.
+RUN mkdir -p /root/.codex && \
+    printf 'approval_policy = "never"\nsandbox_mode = "danger-full-access"\n' > /root/.codex/config.toml
 
 # Capture tool versions at build time for fast shell startup
 COPY scripts/capture-versions.sh /tmp/capture-versions.sh

--- a/sandbox/artifacts/opencode.json
+++ b/sandbox/artifacts/opencode.json
@@ -1,10 +1,6 @@
 {
     "$schema": "https://opencode.ai/config.json",
-    "permission": {
-        "bash": "allow",
-        "edit": "allow",
-        "webfetch": "allow"
-    },
+    "permission": "allow",
     "provider": {
         "apify-openrouter": {
             "npm": "@ai-sdk/openai-compatible",

--- a/sandbox/src/shell-launch.ts
+++ b/sandbox/src/shell-launch.ts
@@ -1,13 +1,33 @@
 /**
  * Translate `?launch=<cmd>` on a /shell URL into the `?arg=-c&arg=...` form
- * ttyd expects. `?launch=` is a convenience: bash invoked with `-c` does not
- * source rcfiles, so we explicitly prepend `source /app/sandbox_bashrc;` to
- * ensure the launched command sees the same env as an interactive shell.
+ * ttyd expects, running <cmd> inside a persistent interactive shell.
+ *
+ * Why the interactive wrapper: ttyd has no `--once`, so when the spawned
+ * process exits the browser reconnects and ttyd respawns it. A bare
+ * `bash -c "...; <cmd>"` exits the moment <cmd> finishes (or fails to start),
+ * which produced a restart loop. Instead we:
+ *   1. source the sandbox rcfile (so <cmd> sees the same env + wrappers),
+ *   2. echo the command so it's visible (as if typed at the prompt),
+ *   3. run it, surfacing a non-zero exit status,
+ *   4. `exec` an interactive shell so the terminal stays alive afterwards —
+ *      keeping any output or errors on screen instead of looping away.
  *
  * Idempotent: if `launch` is absent, the path is returned unchanged. Other
  * query params are preserved in order.
  */
-const BASHRC_SOURCE = 'source /app/sandbox_bashrc;';
+const BASHRC = '/app/sandbox_bashrc';
+const INTERACTIVE_SHELL = `exec bash --rcfile ${BASHRC}`;
+
+/** Build the `bash -c` payload for a launched command. */
+const buildLaunchCommand = (launch: string): string => {
+    if (!launch.trim()) return INTERACTIVE_SHELL;
+    return [
+        `source ${BASHRC};`,
+        `echo "$ ${launch}";`,
+        `${launch} || echo "[command exited with status $?]";`,
+        INTERACTIVE_SHELL,
+    ].join(' ');
+};
 
 export const translateLaunchParam = (path: string): string => {
     const queryIdx = path.indexOf('?');
@@ -19,7 +39,7 @@ export const translateLaunchParam = (path: string): string => {
     if (launch === null) return path;
 
     params.delete('launch');
-    const cmd = launch.trim() ? `${BASHRC_SOURCE} ${launch}` : BASHRC_SOURCE;
+    const cmd = buildLaunchCommand(launch);
 
     const parts: string[] = [
         `arg=${encodeURIComponent('-c')}`,

--- a/sandbox/src/templates/shell.ts
+++ b/sandbox/src/templates/shell.ts
@@ -99,8 +99,17 @@ alias ll='ls -alF'
 alias la='ls -A'
 alias l='ls -CF'
 
-# Print welcome message
-if [ -f /app/welcome.sh ]; then
+# Auto-approve all confirmations for AI coding agents — safe inside the sandbox.
+# Claude Code's settings-based bypass mode shows a blocking confirmation dialog,
+# so we pass --dangerously-skip-permissions explicitly. Defined as a function so
+# it also applies on the non-interactive launch path (bash -c). Codex and
+# OpenCode auto-approve via their own config files.
+claude() { command claude --dangerously-skip-permissions "$@"; }
+
+# Print welcome message (once per session; the launch wrapper sources this
+# rcfile twice — to set up the env, then again for the persistent shell).
+if [ -z "$SANDBOX_WELCOME_SHOWN" ] && [ -f /app/welcome.sh ]; then
+    export SANDBOX_WELCOME_SHOWN=1
     bash /app/welcome.sh
 fi
 `;

--- a/sandbox/src/templates/shell.ts
+++ b/sandbox/src/templates/shell.ts
@@ -92,7 +92,7 @@ export ANTHROPIC_AUTH_TOKEN="\${APIFY_TOKEN}"
 export ANTHROPIC_API_KEY=""
 
 # Colorful prompt
-PS1='\\[\\033[01;32m\\]apify\\[\\033[00m\\]@\\[\\033[01;34m\\]sandbox\\[\\033[00m\\]:\\[\\033[01;33m\\]\\w\\[\\033[00m\\]\\$ '
+PS1='\\[\\033[01;32m\\]actor\\[\\033[00m\\]@\\[\\033[01;34m\\]sandbox\\[\\033[00m\\]:\\[\\033[01;33m\\]\\w\\[\\033[00m\\]\\$ '
 
 # Aliases
 alias ll='ls -alF'

--- a/sandbox/tests/unit/shell-launch.test.ts
+++ b/sandbox/tests/unit/shell-launch.test.ts
@@ -14,23 +14,32 @@ describe('translateLaunchParam', () => {
         assert.equal(translateLaunchParam('/?arg=-c&arg=foo'), '/?arg=-c&arg=foo');
     });
 
-    it('translates launch=<cmd> to arg=-c arg=source bashrc; <cmd>', () => {
+    it('runs launch=<cmd> in a persistent shell, echoing the command and any error', () => {
         const out = translateLaunchParam('/?launch=claude');
-        assert.equal(out, '/?arg=-c&arg=source%20%2Fapp%2Fsandbox_bashrc%3B%20claude');
+        assert.equal(
+            out,
+            '/?arg=-c&arg=source%20%2Fapp%2Fsandbox_bashrc%3B%20echo%20%22%24%20claude%22%3B%20claude%20%7C%7C%20echo%20%22%5Bcommand%20exited%20with%20status%20%24%3F%5D%22%3B%20exec%20bash%20--rcfile%20%2Fapp%2Fsandbox_bashrc',
+        );
     });
 
     it('handles commands with spaces and special chars', () => {
         const out = translateLaunchParam('/?launch=opencode%20tui');
-        assert.equal(out, '/?arg=-c&arg=source%20%2Fapp%2Fsandbox_bashrc%3B%20opencode%20tui');
+        assert.equal(
+            out,
+            '/?arg=-c&arg=source%20%2Fapp%2Fsandbox_bashrc%3B%20echo%20%22%24%20opencode%20tui%22%3B%20opencode%20tui%20%7C%7C%20echo%20%22%5Bcommand%20exited%20with%20status%20%24%3F%5D%22%3B%20exec%20bash%20--rcfile%20%2Fapp%2Fsandbox_bashrc',
+        );
     });
 
     it('preserves other query params (after the injected args)', () => {
         const out = translateLaunchParam('/ws?launch=claude&token=abc');
-        assert.equal(out, '/ws?arg=-c&arg=source%20%2Fapp%2Fsandbox_bashrc%3B%20claude&token=abc');
+        assert.equal(
+            out,
+            '/ws?arg=-c&arg=source%20%2Fapp%2Fsandbox_bashrc%3B%20echo%20%22%24%20claude%22%3B%20claude%20%7C%7C%20echo%20%22%5Bcommand%20exited%20with%20status%20%24%3F%5D%22%3B%20exec%20bash%20--rcfile%20%2Fapp%2Fsandbox_bashrc&token=abc',
+        );
     });
 
-    it('handles empty launch value by just sourcing bashrc', () => {
+    it('opens a persistent interactive shell when launch is empty', () => {
         const out = translateLaunchParam('/?launch=');
-        assert.equal(out, '/?arg=-c&arg=source%20%2Fapp%2Fsandbox_bashrc%3B');
+        assert.equal(out, '/?arg=-c&arg=exec%20bash%20--rcfile%20%2Fapp%2Fsandbox_bashrc');
     });
 });


### PR DESCRIPTION
## Summary
Fixes a restart loop when launching commands via the `?launch=` parameter by wrapping the command in a persistent interactive shell. Previously, commands would exit immediately after completion, causing ttyd to respawn the process repeatedly. Now the shell stays alive after command execution, keeping output visible on screen.

## Key Changes

- **Shell launch wrapper redesign**: Replaced simple command execution with a multi-step wrapper that:
  - Sources the sandbox rcfile for consistent environment and tool wrappers
  - Echoes the command to show what's being executed (like a typed prompt)
  - Captures and displays non-zero exit status
  - Execs an interactive shell to keep the terminal alive after command completion

- **Simplified launch parameter syntax**: Updated actor.json templates to use the cleaner `?launch=<cmd>` form instead of manually constructing `?arg=-c&arg=...` parameters

- **Tool auto-approval configuration**:
  - Added Claude Code wrapper function to pass `--dangerously-skip-permissions` flag
  - Pre-accepted Claude Code onboarding to skip first-run dialogs
  - Configured Codex CLI auto-approval via config.toml
  - Added OpenClaw tool execution policy and exec-approvals.json

- **Shell environment improvements**:
  - Changed prompt username from "apify" to "actor"
  - Added guard to prevent welcome message from displaying twice (since rcfile is sourced twice in the launch wrapper)
  - Added comprehensive comments explaining the launch wrapper behavior and tool approval strategy

- **OpenCode configuration**: Simplified permission model from granular per-tool settings to a single "allow" policy

## Implementation Details

The new `buildLaunchCommand()` function constructs a bash command string that:
1. Sources `/app/sandbox_bashrc` to set up environment and tool wrappers
2. Echoes the command with a `$` prompt prefix for visibility
3. Executes the command with `|| echo "[command exited with status $?]"` to surface failures
4. Execs an interactive bash shell to maintain the terminal session

This approach prevents the restart loop while maintaining a seamless user experience where commands appear to run interactively and any errors remain visible.

https://claude.ai/code/session_01Fr9fjpNTprHnrU5JbUnrmp