### PR TITLE
Write shutdown banner directly to browser terminal sockets

### DIFF
--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -12,8 +12,14 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Build ttyd from source
-RUN git clone --depth 1 https://github.com/tsl0922/ttyd.git /tmp/ttyd \
+# Build ttyd from source, pinned for reproducible builds. The shutdown banner
+# writes ttyd's own WebSocket output frames directly to the browser terminal
+# (see sandbox/src/shutdown.ts, encodeTtydOutputMessage), so a protocol change
+# could silently stop the banner from rendering. Before bumping this version,
+# confirm terminal OUTPUT is still command byte '0' in ttyd's client protocol:
+# https://github.com/tsl0922/ttyd/blob/main/html/src/components/terminal/xterm/index.ts (the Command enum).
+ARG TTYD_VERSION=1.7.7
+RUN git clone --branch "${TTYD_VERSION}" --depth 1 https://github.com/tsl0922/ttyd.git /tmp/ttyd \
     && cd /tmp/ttyd && mkdir build && cd build \
     && cmake .. \
     && make && make install

--- a/sandbox/src/main.ts
+++ b/sandbox/src/main.ts
@@ -37,7 +37,7 @@ import {
     removeProxyMapping,
     saveProxyConfig,
 } from './proxy-config.js';
-import { broadcastToTerminals, buildShutdownBanner } from './shutdown.js';
+import { broadcastToTerminals, buildShutdownBanner, encodeTtydOutputMessage } from './shutdown.js';
 import { parseSkills } from './skills.js';
 import { getBrowsePageHTML } from './templates/browse.js';
 import { getLandingPageHTML, getLLMsMarkdown } from './templates/landing.js';
@@ -904,23 +904,55 @@ if (!isLocalMode) {
 // Shutdown notifications
 // ============================================================================
 
-/** Delay before exiting so ttyd can flush the banner to connected browsers. */
+/** Delay before a self-initiated exit so the banner flushes to connected browsers. */
 const TERMINAL_FLUSH_DELAY_MS = 1000;
 
 /**
- * Show a shutdown banner in every open browser terminal. No-op in local mode,
- * where /dev/pts would hold the developer's own terminals rather than ttyd's.
+ * Browser-facing WebSocket sockets for open /shell terminals. The terminal is
+ * served through a proxy (browser ↔ this Actor ↔ ttyd), so these are the sockets
+ * we write the shutdown banner to directly. Populated by the upgrade handler
+ * below; entries remove themselves when the connection closes.
+ */
+const terminalSockets = new Set<Duplex>();
+
+/** Guard so a shutdown shows the banner once, even if several stop events fire. */
+let shutdownBannerSent = false;
+
+/**
+ * Show a shutdown banner in every open browser terminal. No-op in local mode.
+ *
+ * Writes a ready-made ttyd output frame straight to each browser socket rather
+ * than relaying it through ttyd: at shutdown this process (the proxy) is about
+ * to exit, and a direct write reaches the kernel — and thus the browser — even
+ * if the long way round (PTY → ttyd → proxy → browser) wouldn't finish in time.
+ * Falls back to the PTY devices only if no browser socket is tracked.
  * @param reason - Human-readable explanation of why the Actor is stopping.
  */
 const notifyTerminalsOfShutdown = (reason: string): void => {
-    if (isLocalMode) return;
-    broadcastToTerminals(buildShutdownBanner(reason, process.env.ACTOR_RUN_ID));
+    if (isLocalMode || shutdownBannerSent) return;
+    shutdownBannerSent = true;
+
+    const banner = buildShutdownBanner(reason, process.env.ACTOR_RUN_ID);
+    const frame = encodeTtydOutputMessage(banner);
+    let delivered = 0;
+    for (const socket of terminalSockets) {
+        try {
+            socket.write(frame);
+            delivered += 1;
+        } catch {
+            // Socket already half-closed between iterations — ignore.
+        }
+    }
+
+    // No browser proxied through us (e.g. a directly attached ttyd): fall back
+    // to writing the banner to the PTY devices ttyd reads from.
+    if (delivered === 0) broadcastToTerminals(banner);
 };
 
 /**
- * Notify open terminals, then exit the Actor. The brief delay lets ttyd flush
- * the banner over the WebSocket before the process tears down the connection
- * (after which the terminal only shows ttyd's "Press ⏎ to Reconnect" overlay).
+ * Notify open terminals, then exit the Actor. The brief delay lets the banner
+ * flush over the WebSocket before the process tears down the connection (after
+ * which the terminal only shows ttyd's "Press ⏎ to Reconnect" overlay).
  * @param reason - Human-readable explanation of why the Actor is stopping.
  */
 const shutdownWithNotice = async (reason: string): Promise<void> => {
@@ -931,8 +963,10 @@ const shutdownWithNotice = async (reason: string): Promise<void> => {
     await Actor.exit({ statusMessage: reason });
 };
 
-// Surface platform-initiated stops (migration, abort) in the terminal too. These
-// fire synchronously; the platform controls process exit, so we only broadcast.
+// Surface platform-initiated stops in the terminal too. The migration/abort
+// events are advance notices, and the platform stops the container with a
+// termination signal; in every case the banner is written synchronously so it
+// reaches the browser before the process exits.
 if (!isLocalMode) {
     Actor.on('migrating', () => {
         notifyTerminalsOfShutdown('Actor is migrating to a new host and will resume shortly. Reconnect in a moment.');
@@ -940,6 +974,14 @@ if (!isLocalMode) {
     Actor.on('aborting', () => {
         notifyTerminalsOfShutdown('Actor run is being aborted.');
     });
+
+    // Only hook signals the SDK already handles, so we add the banner without
+    // taking over termination — a lone SIGTERM listener would suppress Node's
+    // default exit and leave the container hanging until the platform SIGKILLs it.
+    const notifyOnSignal = (): void => notifyTerminalsOfShutdown('Actor run is stopping.');
+    for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+        if (process.listenerCount(signal) > 0) process.prependListener(signal, notifyOnSignal);
+    }
 }
 
 // Manual HTTP Proxy for ttyd
@@ -986,6 +1028,16 @@ server.on('upgrade', (req, socket, head) => {
         req.url = req.url.replace(/^\/shell/, '') || '/';
         req.url = translateLaunchParam(req.url);
         log.info('Proxying shell WebSocket upgrade', { url: req.url });
+
+        // Remember this browser socket so the shutdown banner can be written to
+        // it directly (see notifyTerminalsOfShutdown), and forget it on close.
+        terminalSockets.add(socket as Duplex);
+        const forgetSocket = (): void => {
+            terminalSockets.delete(socket as Duplex);
+        };
+        socket.on('close', forgetSocket);
+        socket.on('end', forgetSocket);
+        socket.on('error', forgetSocket);
 
         // Track activity on WebSocket data
         socket.on('data', () => {

--- a/sandbox/src/shutdown.ts
+++ b/sandbox/src/shutdown.ts
@@ -88,3 +88,52 @@ export const buildShutdownBanner = (reason: string, runId?: string): string => {
 
     return `${lines.join('\r\n')}\r\n`;
 };
+
+/**
+ * ttyd command byte for terminal output. ttyd's WebSocket subprotocol prefixes
+ * every server→client message with a one-byte command; '0' (0x30) means "write
+ * the rest straight to the terminal".
+ */
+const TTYD_OUTPUT_COMMAND = 0x30; // '0'
+
+/** WebSocket header byte: FIN set, opcode 0x2 (binary frame). */
+const WS_FIN_BINARY = 0x82;
+
+/**
+ * Encode text as a ttyd output message inside a single binary WebSocket frame,
+ * ready to write straight to a browser's terminal socket.
+ *
+ * The terminal is served through a proxy (browser ↔ this Actor ↔ ttyd). When the
+ * Actor stops, the proxy stops with it, so relaying a banner the long way round
+ * (PTY → ttyd → proxy → browser) usually loses the race against process exit.
+ * Writing a ready-made frame directly to the browser-facing socket hands the
+ * bytes to the kernel immediately, so they reach the terminal even if the
+ * process exits a moment later.
+ *
+ * Server→client frames are never masked (RFC 6455 §5.1), so the frame is just a
+ * FIN+binary header, the payload length, and the payload (command byte + text).
+ *
+ * @param text - Text to display in the terminal. Use `\r\n` line breaks.
+ * @returns The encoded WebSocket frame.
+ */
+export const encodeTtydOutputMessage = (text: string): Buffer => {
+    const payload = Buffer.concat([Buffer.from([TTYD_OUTPUT_COMMAND]), Buffer.from(text, 'utf8')]);
+    const len = payload.length;
+
+    let header: Buffer;
+    if (len < 126) {
+        header = Buffer.from([WS_FIN_BINARY, len]);
+    } else if (len < 0x10000) {
+        // 126 signals a 16-bit length follows.
+        // eslint-disable-next-line no-bitwise -- splitting the length into bytes needs shifts/masks
+        header = Buffer.from([WS_FIN_BINARY, 126, (len >> 8) & 0xff, len & 0xff]);
+    } else {
+        // 127 signals a 64-bit length follows.
+        header = Buffer.alloc(10);
+        header[0] = WS_FIN_BINARY;
+        header[1] = 127;
+        header.writeBigUInt64BE(BigInt(len), 2);
+    }
+
+    return Buffer.concat([header, payload]);
+};

--- a/sandbox/tests/unit/shutdown.test.ts
+++ b/sandbox/tests/unit/shutdown.test.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/no-floating-promises -- node:test's describe/it return promises by design */
+/* eslint-disable no-bitwise -- decoding a WebSocket frame in the test mirrors the bit-level wire format */
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { broadcastToTerminals, buildShutdownBanner } from '../../src/shutdown.js';
+import { broadcastToTerminals, buildShutdownBanner, encodeTtydOutputMessage } from '../../src/shutdown.js';
 
 describe('buildShutdownBanner', () => {
     it('includes the shutdown headline and the reason', () => {
@@ -35,5 +36,45 @@ describe('buildShutdownBanner', () => {
 describe('broadcastToTerminals', () => {
     it('does nothing and does not throw when the pts directory is absent', () => {
         assert.doesNotThrow(() => broadcastToTerminals('hi', '/no/such/pts/dir'));
+    });
+});
+
+describe('encodeTtydOutputMessage', () => {
+    /** Decode a frame the way ttyd's browser client does: one binary frame, drop the command byte. */
+    const decode = (frame: Buffer): { command: string; text: string } => {
+        assert.equal(frame[0], 0x82, 'first byte must be FIN + binary opcode');
+        assert.equal(frame[1] & 0x80, 0, 'server-to-client frames must not be masked');
+
+        let len = frame[1] & 0x7f;
+        let offset = 2;
+        if (len === 126) {
+            len = frame.readUInt16BE(2);
+            offset = 4;
+        } else if (len === 127) {
+            len = Number(frame.readBigUInt64BE(2));
+            offset = 10;
+        }
+
+        const payload = frame.subarray(offset, offset + len);
+        return { command: String.fromCharCode(payload[0]), text: payload.subarray(1).toString('utf8') };
+    };
+
+    it('wraps text as a ttyd OUTPUT ("0") message that round-trips', () => {
+        const { command, text } = decode(encodeTtydOutputMessage('hello world'));
+        assert.equal(command, '0');
+        assert.equal(text, 'hello world');
+    });
+
+    it('round-trips a full shutdown banner (length > 125 uses the extended header)', () => {
+        const banner = buildShutdownBanner('Actor shut down after 15 minutes of inactivity.', 'RUN123');
+        assert.ok(banner.length > 125, 'banner should be long enough to exercise the 16-bit length path');
+        const { command, text } = decode(encodeTtydOutputMessage(banner));
+        assert.equal(command, '0');
+        assert.equal(text, banner);
+    });
+
+    it('preserves multi-byte UTF-8 by measuring length in bytes, not characters', () => {
+        const { text } = decode(encodeTtydOutputMessage('héllo — 🚀'));
+        assert.equal(text, 'héllo — 🚀');
     });
 });


### PR DESCRIPTION
The terminal is proxied (browser ↔ Actor ↔ ttyd), so #40's approach — write the banner to the PTY and let ttyd relay it back — lost the race against process exit on platform-initiated stops (abort, migration, run timeout). Only the idle path's flush delay reliably worked, so in practice the banner rarely showed.

- Write the banner straight to the browser WebSocket as a ttyd output frame, so the bytes reach the kernel before the proxy process dies; fall back to the old PTY broadcast only when no socket is tracked.
- Route abort, migration, and (defensively, only if the SDK already handles them) SIGINT/SIGTERM through it, with a one-shot guard so the banner shows once.
- Add unit tests that decode the frame the way ttyd's browser client does (incl. extended-length and multi-byte UTF-8).

A hard SIGKILL still shows nothing — no code runs at that point.

https://claude.ai/code/session_01KrCLcsSMPpsyWwuTyCzYv8