### PR TITLE
Support GitHub repo URLs in skills input

### DIFF
--- a/sandbox/.actor/actor.json
+++ b/sandbox/.actor/actor.json
@@ -19,10 +19,10 @@
             "skills": {
                 "title": "Skills",
                 "type": "string",
-                "description": "Skill packages to install for the AI coding agent — SKILLS.md files with specialized instructions (see https://skills.sh/). One skill per line, e.g. `anthropics/skills` (blank lines and `#` comments are ignored), or a JSON array like `[\"apify/agent-skills\", \"anthropics/skills\"]`.",
+                "description": "Skill packages to install for the AI coding agent — SKILLS.md files with specialized instructions (see https://skills.sh/). One skill per line — a GitHub `owner/repo` (e.g. `anthropics/skills`) or repo URL (e.g. `https://github.com/anthropics/skills`); blank lines and `#` comments are ignored. Also accepts a JSON array like `[\"apify/agent-skills\", \"anthropics/skills\"]`.",
                 "editor": "textarea",
                 "default": "apify/agent-skills",
-                "prefill": "apify/agent-skills\n# One skill per line, e.g. anthropics/skills"
+                "prefill": "apify/agent-skills\n# One skill per line — owner/repo or a GitHub repo URL:\n# anthropics/skills\n# https://github.com/anthropics/skills"
             },
             "nodeDependencies": {
                 "title": "Node.js dependencies",

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -416,7 +416,7 @@ mkdir -p /sandbox/custom-data && chmod 755 /sandbox/custom-data
 
 Install skill packages that provide specialized instructions for AI coding agents. Skills are SKILLS.md files that enhance agent capabilities.
 
-- Specify skills via the "Skills" input — one package per line (e.g. `anthropics/skills`), or a JSON array
+- Specify skills via the "Skills" input — one per line: a GitHub `owner/repo` (e.g. `anthropics/skills`) or repo URL (e.g. `https://github.com/anthropics/skills`), or a JSON array
 - Example: `apify/agent-skills`
 - Skills are installed globally during Actor startup
 - For more info see [skills.sh](https://skills.sh/)

--- a/sandbox/src/skills.ts
+++ b/sandbox/src/skills.ts
@@ -39,8 +39,10 @@ const parseLines = (raw: string): string[] => {
 
 /**
  * Parse the user-supplied `skills` input into a de-duplicated list of skill
- * identifiers for `installSkills`. Accepts either:
- *  - one skill per line (e.g. `anthropics/skills`; blank lines and `#` comments ignored), or
+ * identifiers for `installSkills`. Each identifier is passed through unchanged to
+ * the `skills` CLI, which accepts a GitHub `owner/repo` (e.g. `anthropics/skills`)
+ * or a repo URL (e.g. `https://github.com/anthropics/skills`). Accepts either:
+ *  - one skill per line (blank lines and `#` comments ignored), or
  *  - a JSON array of skill name strings (input starting with `[` or `{` is parsed
  *    as JSON; any non-array JSON yields no skills).
  *

--- a/sandbox/src/types.ts
+++ b/sandbox/src/types.ts
@@ -15,8 +15,9 @@ export interface ProxyMapping {
 export interface ActorInput {
     /**
      * Skill packages to install for the AI coding agent (SKILLS.md files).
-     * Accepts one skill per line (e.g. `anthropics/skills`; blank lines and
-     * `#` comments ignored) or a JSON array of skill name strings.
+     * Accepts one skill per line — a GitHub `owner/repo` (e.g. `anthropics/skills`)
+     * or repo URL (e.g. `https://github.com/anthropics/skills`); blank lines and
+     * `#` comments ignored — or a JSON array of skill name strings.
      */
     skills?: string;
 

--- a/sandbox/tests/unit/skills.test.ts
+++ b/sandbox/tests/unit/skills.test.ts
@@ -100,6 +100,29 @@ describe('parseSkills', () => {
         });
     });
 
+    describe('GitHub repo URLs', () => {
+        it('passes a repo URL through unchanged (line format)', () => {
+            assert.deepEqual(parseSkills('https://github.com/anthropics/skills'), [
+                'https://github.com/anthropics/skills',
+            ]);
+        });
+
+        it('passes a repo URL with a subpath through unchanged', () => {
+            const input = 'https://github.com/anthropics/skills/tree/main/skills/web-design';
+            assert.deepEqual(parseSkills(input), [input]);
+        });
+
+        it('mixes owner/repo shorthand and repo URLs across lines', () => {
+            const input = 'apify/agent-skills\nhttps://github.com/anthropics/skills';
+            assert.deepEqual(parseSkills(input), ['apify/agent-skills', 'https://github.com/anthropics/skills']);
+        });
+
+        it('passes repo URLs through unchanged (JSON array)', () => {
+            const input = '["apify/agent-skills", "https://github.com/anthropics/skills"]';
+            assert.deepEqual(parseSkills(input), ['apify/agent-skills', 'https://github.com/anthropics/skills']);
+        });
+    });
+
     describe('array input (legacy stringList)', () => {
         it('cleans and de-duplicates a string array', () => {
             const input = [' apify/agent-skills ', 'anthropics/skills', 'apify/agent-skills', ''];


### PR DESCRIPTION
- Document that the `skills` input accepts a GitHub repo URL (e.g. `https://github.com/anthropics/skills`) as well as the `owner/repo` shorthand — surfaced in the input description, prefill example, README, and doc comments, since it was supported but undiscoverable.
- No parsing change needed: `parseSkills` already passes identifiers through unchanged to the skills CLI, which handles both forms. Added tests to lock in URL pass-through (line + JSON formats, incl. subpaths).

https://claude.ai/code/session_016XgcmN1VU9uvoaAcD1rdLF