### PR TITLE
Add libuv1t64 runtime dependency to sandbox Dockerfile

### DIFF
--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -50,8 +50,9 @@ FROM node:24-trixie-slim
 # ttyd is compiled from source in the builder stage and copied into this stage
 # as a finished binary (see `COPY --from=builder .../ttyd` below), so the runtime
 # only needs the *runtime* shared libraries it links against (libjson-c5,
-# libwebsockets19t64) — not the `-dev` packages, headers, and build toolchain
-# that the compile step required.
+# libwebsockets19t64, libuv1t64) — not the `-dev` packages, headers, and build
+# toolchain that the compile step required. The `t64` suffix reflects Debian
+# trixie's 64-bit time_t transition.
 RUN apt-get update && apt-get install -y \
     bash \
     curl \
@@ -63,6 +64,7 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     libjson-c5 \
     libwebsockets19t64 \
+    libuv1t64 \
     libsecret-1-0 \
     procps \
     jq \
@@ -127,8 +129,8 @@ COPY --from=builder /build/dist /app/dist
 COPY --from=builder /usr/local/bin/ttyd /usr/local/bin/ttyd
 
 # Verify the copied-in ttyd binary can load its runtime shared libraries
-# (libwebsockets, libjson-c). Fails the build early if a runtime lib package is
-# missing or renamed, rather than shipping a broken interactive shell.
+# (libwebsockets, libjson-c, libuv). Fails the build early if a runtime lib
+# package is missing or renamed, rather than shipping a broken interactive shell.
 RUN ttyd --version
 
 # Copy package.json and production node_modules from builder


### PR DESCRIPTION
- `ttyd` is compiled in the builder stage and copied into the runtime stage as a finished binary, but the runtime stage only installed `libjson-c5` and `libwebsockets19t64` — not `libuv`, which ttyd also links. The `ttyd --version` smoke test caught it and failed the build with `libuv.so.1: cannot open shared object file`.
- Install `libuv1t64` alongside the other ttyd runtime libs (the `t64` suffix matches Debian trixie's 64-bit time_t transition, consistent with the existing `libwebsockets19t64`).

https://claude.ai/code/session_013HfGo4Dz2EZ1TghTqDFhT8