### PR TITLE
Fix the interactive shell and surface ttyd startup failures

### DIFF
--- a/sandbox/src/main.ts
+++ b/sandbox/src/main.ts
@@ -42,6 +42,13 @@ import { parseSkills } from './skills.js';
 import { getBrowsePageHTML } from './templates/browse.js';
 import { getLandingPageHTML, getLLMsMarkdown } from './templates/landing.js';
 import { SANDBOX_BASHRC, WELCOME_SCRIPT } from './templates/shell.js';
+import {
+    appendTtydOutput,
+    buildShellUnavailableMessage,
+    isTtydStartupCrash,
+    nextTtydRestartDelayMs,
+    TTYD_RESTART_MIN_MS,
+} from './ttyd.js';
 import type { ActorInput, ProxyMapping } from './types.js';
 
 // Track initialization state
@@ -875,24 +882,71 @@ app.post('/exec', async (req: Request, res: Response) => {
 // ============================================================================
 const shellPort = 7681;
 
+// ttyd's last words: the tail of its stdout/stderr (or a spawn error). Recorded
+// so a crash — e.g. a missing shared library — shows up in the Actor log and in
+// the /shell proxy response instead of a bare exit code. The delay grows as ttyd
+// keeps failing to start (see nextTtydRestartDelayMs).
+let lastTtydError = '';
+let ttydRestartDelayMs = TTYD_RESTART_MIN_MS;
+
 // Spawn ttyd process
 const spawnTtyd = () => {
     log.info('Spawning ttyd process...', { port: shellPort });
+    const startedAt = Date.now();
 
-    // Run ttyd with custom bashrc for better UX and environment alignment
+    // Run ttyd with custom bashrc for better UX and environment alignment. Pipe
+    // its stdio (rather than ignoring it) so a startup failure is captured.
     const ttyd = spawn('ttyd', ['-p', shellPort.toString(), '-a', '-W', 'bash', '--rcfile', '/app/sandbox_bashrc'], {
-        stdio: 'ignore',
+        stdio: ['ignore', 'pipe', 'pipe'],
         cwd: SANDBOX_DIR,
         env: { ...process.env },
     });
 
+    // Keep only the tail of ttyd's output — its startup/error messages are short.
+    let recentOutput = '';
+    const capture = (chunk: Buffer): void => {
+        recentOutput = appendTtydOutput(recentOutput, chunk.toString());
+    };
+    ttyd.stdout?.on('data', capture);
+    ttyd.stderr?.on('data', capture);
+
+    // Schedule exactly one restart per spawn: a failed spawn emits 'error' (no
+    // 'exit'), a started process emits 'exit'; guard against both firing.
+    let settled = false;
+    const restartAfter = (crashed: boolean): void => {
+        if (settled) return;
+        settled = true;
+        const delay = crashed ? ttydRestartDelayMs : TTYD_RESTART_MIN_MS;
+        ttydRestartDelayMs = nextTtydRestartDelayMs(ttydRestartDelayMs, crashed);
+        setTimeout(spawnTtyd, delay);
+    };
+
     ttyd.on('error', (err) => {
+        lastTtydError = err.message;
         log.error('Failed to start ttyd', { error: err.message });
+        restartAfter(true);
     });
 
-    ttyd.on('exit', (code) => {
-        log.warning('ttyd process exited', { code });
-        setTimeout(spawnTtyd, 5000);
+    ttyd.on('exit', (code, signal) => {
+        const aliveMs = Date.now() - startedAt;
+        const output = recentOutput.trim();
+        if (output) lastTtydError = output;
+
+        // A fast exit means ttyd never really came up (missing shared library,
+        // port already bound, bad args). Shout, since the old fixed-5s retry with
+        // no detail produced an invisible crash loop behind "Shell Proxy Error".
+        const crashed = isTtydStartupCrash(aliveMs);
+        if (crashed) {
+            log.error('ttyd exited immediately — interactive shell is unavailable', {
+                code,
+                signal,
+                aliveMs,
+                output: output || '(no output captured)',
+            });
+        } else {
+            log.warning('ttyd process exited; restarting', { code, signal, aliveMs });
+        }
+        restartAfter(crashed);
     });
 };
 
@@ -1008,9 +1062,17 @@ app.all('/shell{*rest}', (req, res) => {
     });
 
     proxyReq.on('error', (err) => {
-        log.error('Manual proxy error', { error: err.message });
+        // ECONNREFUSED means ttyd isn't listening — it almost always crashed on
+        // startup (see spawnTtyd, which records its last output in lastTtydError).
+        // Surface that as a 503 instead of an opaque 500 so the cause is visible.
+        const ttydDown = (err as NodeJS.ErrnoException).code === 'ECONNREFUSED';
+        log.error('Manual proxy error', { error: err.message, ttydDown });
         if (!res.headersSent) {
-            res.status(500).send('Shell Proxy Error');
+            if (ttydDown) {
+                res.status(503).type('text/plain').send(buildShellUnavailableMessage(lastTtydError));
+            } else {
+                res.status(502).type('text/plain').send(`Shell proxy error: ${err.message}`);
+            }
         }
     });
 
@@ -1021,6 +1083,18 @@ app.all('/shell{*rest}', (req, res) => {
 const wsProxy = httpProxy.createProxyServer({
     target: `http://127.0.0.1:${shellPort}`,
     ws: true,
+});
+
+// Without this handler a WebSocket upgrade to a down ttyd emits an 'error' with
+// no listener, which Node escalates to an uncaught exception that can take down
+// the whole server. ttyd is restarted by spawnTtyd; just close the browser
+// socket so the terminal shows its reconnect overlay and retries.
+wsProxy.on('error', (err, _req, resOrSocket) => {
+    log.warning('Shell WebSocket proxy error', { error: (err as Error).message });
+    const socket = resOrSocket as Duplex | undefined;
+    if (socket && typeof socket.destroy === 'function' && !socket.destroyed) {
+        socket.destroy();
+    }
 });
 
 server.on('upgrade', (req, socket, head) => {

--- a/sandbox/src/ttyd.ts
+++ b/sandbox/src/ttyd.ts
@@ -1,0 +1,65 @@
+/**
+ * Supervision helpers for the ttyd process that backs the interactive /shell
+ * terminal. The process is spawned and restarted in main.ts; the pure decision
+ * logic lives here so it can be unit-tested without spawning a real process.
+ *
+ * Why this exists: ttyd used to be spawned with `stdio: 'ignore'` and restarted
+ * on a fixed 5s timer, so a startup failure (e.g. a missing shared library —
+ * the libuv regression that broke the shell) surfaced only as a repeating
+ * "ttyd process exited {code:1}" with no reason, while the /shell proxy returned
+ * an opaque 500 "Shell Proxy Error". These helpers support capturing ttyd's
+ * output, backing off between restarts, and telling the user why the shell is
+ * down.
+ */
+
+/** Restart backoff bounds (ms). */
+export const TTYD_RESTART_MIN_MS = 1000;
+export const TTYD_RESTART_MAX_MS = 30000;
+
+/**
+ * An exit within this window of startup means ttyd never really came up (bad
+ * args, missing shared library, port already in use) rather than a long-lived
+ * server that later died. We back off and log loudly in that case.
+ */
+export const TTYD_CRASH_WINDOW_MS = 2000;
+
+/** How many characters of ttyd's recent stdout/stderr to retain for diagnostics. */
+export const TTYD_OUTPUT_LIMIT = 2048;
+
+/** True if ttyd exited fast enough to count as a startup crash rather than a normal exit. */
+export const isTtydStartupCrash = (aliveMs: number): boolean => aliveMs < TTYD_CRASH_WINDOW_MS;
+
+/**
+ * The delay to use the next time ttyd needs restarting. Startup crashes back off
+ * exponentially up to the cap, so a permanently broken ttyd doesn't spam the log;
+ * a process that ran for a while before exiting resets to the minimum so it
+ * recovers promptly.
+ */
+export const nextTtydRestartDelayMs = (currentDelayMs: number, isCrash: boolean): number => {
+    if (!isCrash) return TTYD_RESTART_MIN_MS;
+    const doubled = Math.max(currentDelayMs, TTYD_RESTART_MIN_MS) * 2;
+    return Math.min(doubled, TTYD_RESTART_MAX_MS);
+};
+
+/** Append a chunk to the rolling output buffer, keeping only the last `limit` characters. */
+export const appendTtydOutput = (buffer: string, chunk: string, limit = TTYD_OUTPUT_LIMIT): string =>
+    (buffer + chunk).slice(-limit);
+
+/**
+ * Plain-text body returned by the /shell proxy when ttyd isn't reachable. Includes
+ * ttyd's last output when we have it, so the cause (e.g. a missing shared library)
+ * is visible in the browser instead of an opaque error.
+ */
+export const buildShellUnavailableMessage = (lastTtydOutput: string): string => {
+    const lines = ['Interactive shell is not available — the terminal backend (ttyd) is not running.'];
+    const detail = lastTtydOutput.trim();
+    if (detail) {
+        lines.push('', 'Last ttyd output:', detail);
+    }
+    lines.push(
+        '',
+        'The sandbox keeps trying to restart it — reload this page in a few seconds.',
+        'If the problem persists, check the Actor run log.',
+    );
+    return `${lines.join('\n')}\n`;
+};

--- a/sandbox/tests/unit/ttyd.test.ts
+++ b/sandbox/tests/unit/ttyd.test.ts
@@ -1,0 +1,74 @@
+/* eslint-disable @typescript-eslint/no-floating-promises -- node:test's describe/it return promises by design */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+    appendTtydOutput,
+    buildShellUnavailableMessage,
+    isTtydStartupCrash,
+    nextTtydRestartDelayMs,
+    TTYD_CRASH_WINDOW_MS,
+    TTYD_OUTPUT_LIMIT,
+    TTYD_RESTART_MAX_MS,
+    TTYD_RESTART_MIN_MS,
+} from '../../src/ttyd.js';
+
+describe('isTtydStartupCrash', () => {
+    it('treats a fast exit as a startup crash', () => {
+        assert.equal(isTtydStartupCrash(0), true);
+        assert.equal(isTtydStartupCrash(TTYD_CRASH_WINDOW_MS - 1), true);
+    });
+
+    it('treats a long-lived process exit as a normal exit', () => {
+        assert.equal(isTtydStartupCrash(TTYD_CRASH_WINDOW_MS), false);
+        assert.equal(isTtydStartupCrash(60_000), false);
+    });
+});
+
+describe('nextTtydRestartDelayMs', () => {
+    it('doubles the delay on each crash, capped at the maximum', () => {
+        let delay = TTYD_RESTART_MIN_MS;
+        const seen: number[] = [];
+        for (let i = 0; i < 8; i++) {
+            seen.push(delay);
+            delay = nextTtydRestartDelayMs(delay, true);
+        }
+        assert.deepEqual(seen, [1000, 2000, 4000, 8000, 16000, 30000, 30000, 30000]);
+        assert.ok(seen.every((d) => d <= TTYD_RESTART_MAX_MS));
+    });
+
+    it('resets to the minimum after a normal exit', () => {
+        assert.equal(nextTtydRestartDelayMs(TTYD_RESTART_MAX_MS, false), TTYD_RESTART_MIN_MS);
+    });
+});
+
+describe('appendTtydOutput', () => {
+    it('appends chunks', () => {
+        assert.equal(appendTtydOutput('foo', 'bar'), 'foobar');
+    });
+
+    it('keeps only the last `limit` characters', () => {
+        assert.equal(appendTtydOutput('abcd', 'ef', 3), 'def');
+    });
+
+    it('defaults to the output limit and never grows unbounded', () => {
+        const out = appendTtydOutput('x'.repeat(TTYD_OUTPUT_LIMIT), 'y'.repeat(100));
+        assert.equal(out.length, TTYD_OUTPUT_LIMIT);
+        assert.ok(out.endsWith('y'.repeat(100)));
+    });
+});
+
+describe('buildShellUnavailableMessage', () => {
+    it('includes ttyd output when available', () => {
+        const msg = buildShellUnavailableMessage('ttyd: error while loading shared libraries: libuv.so.1');
+        assert.match(msg, /terminal backend \(ttyd\) is not running/);
+        assert.match(msg, /Last ttyd output:/);
+        assert.match(msg, /libuv\.so\.1/);
+    });
+
+    it('omits the output section when there is nothing to show', () => {
+        const msg = buildShellUnavailableMessage('   ');
+        assert.doesNotMatch(msg, /Last ttyd output:/);
+        assert.match(msg, /reload this page/);
+    });
+});


### PR DESCRIPTION
The shell only ever showed "Shell Proxy Error" because ttyd was crash-looping on startup: the image shrink (#53) dropped the libwebsockets libuv event-loop plugin that ttyd needs.

- Reinstall `libwebsockets-evlib-uv` in the runtime image. libwebsockets `dlopen()`s it when ttyd creates its context, so without it ttyd dies with `lws_create_context: failed to load evlib_uv` on every start. It's loaded at runtime, not linked, so `ldd`/`ttyd --version` never revealed it was missing (which is why #54's libuv fix couldn't catch it). Verified on the live image — ttyd reaches "Listening on port" once it's installed.
- Replace the `ttyd --version` build check with a real server-start smoke test (assert "Listening on port") so a missing plugin or runtime lib fails the build instead of the shell.
- Capture ttyd's stdout/stderr (was `stdio: 'ignore'`) and return 503 with that output from `/shell` when the backend is down — this is what surfaced the `evlib_uv` error in the first place. Also add the missing `wsProxy` error handler (a WebSocket upgrade to a down ttyd was an unhandled `error` that could crash the server) and back off restarts instead of a fixed 5s loop.

https://claude.ai/code/session_01PYQioHAT3hCejhwdY8HhLn