### PR TITLE
Simplify shell prompt to show only working directory

### DIFF
--- a/sandbox/src/templates/shell.ts
+++ b/sandbox/src/templates/shell.ts
@@ -96,8 +96,8 @@ export ANTHROPIC_BASE_URL="https://openrouter.apify.actor/api"
 export ANTHROPIC_AUTH_TOKEN="\${APIFY_TOKEN}"
 export ANTHROPIC_API_KEY=""
 
-# Colorful prompt
-PS1='\\[\\033[01;32m\\]apify\\[\\033[00m\\]@\\[\\033[01;34m\\]sandbox\\[\\033[00m\\]:\\[\\033[01;33m\\]\\w\\[\\033[00m\\]\\$ '
+# Colorful prompt (working directory only, no user/host)
+PS1='\\[\\033[01;33m\\]\\w\\[\\033[00m\\]\\$ '
 
 # Aliases
 alias ll='ls -alF'


### PR DESCRIPTION
## Summary
Simplified the bash prompt configuration in the shell template to display only the working directory, removing the user and host information.

## Changes
- Updated `PS1` prompt string to remove `apify@sandbox` prefix
- Kept only the working directory (`\w`) and command prompt (`\$`) in the prompt
- Changed color scheme from multi-color (green user, blue host, yellow directory) to single yellow color for the directory
- Updated comment to reflect the new prompt behavior

## Details
The new prompt is more concise and focuses on the essential information (current working directory) while maintaining visual distinction through color coding. This reduces visual clutter in the terminal while keeping the most relevant context for users working in the sandbox environment.

https://claude.ai/code/session_01TZbAeDBYzGrRYtawNdTKQw