### PR TITLE
Explain terminal disconnects via ttyd's reconnect overlay

### DIFF
--- a/sandbox/src/main.ts
+++ b/sandbox/src/main.ts
@@ -41,7 +41,7 @@ import { broadcastToTerminals, buildShutdownBanner, encodeTtydOutputMessage } fr
 import { parseSkills } from './skills.js';
 import { getBrowsePageHTML } from './templates/browse.js';
 import { getLandingPageHTML, getLLMsMarkdown } from './templates/landing.js';
-import { SANDBOX_BASHRC, WELCOME_SCRIPT } from './templates/shell.js';
+import { injectTerminalReconnectScript, SANDBOX_BASHRC, WELCOME_SCRIPT } from './templates/shell.js';
 import {
     appendTtydOutput,
     buildShellUnavailableMessage,
@@ -1017,10 +1017,17 @@ const shutdownWithNotice = async (reason: string): Promise<void> => {
     await Actor.exit({ statusMessage: reason });
 };
 
-// Surface platform-initiated stops in the terminal too. The migration/abort
-// events are advance notices, and the platform stops the container with a
-// termination signal; in every case the banner is written synchronously so it
-// reaches the browser before the process exits.
+// Surface the platform stops the SDK tells us about in advance: `migrating`
+// (before a host migration) and `aborting` (only on a *graceful* abort). Both
+// arrive over the SDK's events WebSocket, ahead of the process being torn down,
+// so the banner has time to flush.
+//
+// Everything else — run timeout, a hard abort, platform scale-down — kills the
+// container with a signal and no advance event (the SDK installs no SIGTERM/
+// SIGINT handlers; it's event-driven). There's no reliable way to flush a banner
+// from a dying process, so those cases are covered in the browser instead: the
+// reconnect overlay injected into ttyd's page (see injectTerminalReconnectScript)
+// relabels the disconnect and reports "Actor probably finished" on a failed retry.
 if (!isLocalMode) {
     Actor.on('migrating', () => {
         notifyTerminalsOfShutdown('Actor is migrating to a new host and will resume shortly. Reconnect in a moment.');
@@ -1028,14 +1035,6 @@ if (!isLocalMode) {
     Actor.on('aborting', () => {
         notifyTerminalsOfShutdown('Actor run is being aborted.');
     });
-
-    // Only hook signals the SDK already handles, so we add the banner without
-    // taking over termination — a lone SIGTERM listener would suppress Node's
-    // default exit and leave the container hanging until the platform SIGKILLs it.
-    const notifyOnSignal = (): void => notifyTerminalsOfShutdown('Actor run is stopping.');
-    for (const signal of ['SIGINT', 'SIGTERM'] as const) {
-        if (process.listenerCount(signal) > 0) process.prependListener(signal, notifyOnSignal);
-    }
 }
 
 // Manual HTTP Proxy for ttyd
@@ -1046,19 +1045,49 @@ app.all('/shell{*rest}', (req, res) => {
         path = `/${  path}`;
     }
     path = translateLaunchParam(path);
+    // Ask ttyd for an uncompressed response so the terminal HTML can be rewritten
+    // (see injectTerminalReconnectScript below). ttyd's assets are tiny, so losing
+    // gzip here is negligible.
+    const headers = { ...req.headers, 'accept-encoding': 'identity' };
     const options = {
         hostname: '127.0.0.1',
         port: shellPort,
         path,
         method: req.method,
-        headers: req.headers,
+        headers,
     };
 
     const proxyReq = http.request(options, (proxyRes) => {
-        if (proxyRes.statusCode) {
-            res.writeHead(proxyRes.statusCode, proxyRes.headers);
+        // Inject the client-side reconnect notice into ttyd's terminal page. The
+        // server can't reliably push a shutdown message as the container is killed,
+        // so the browser relabels ttyd's reconnect overlay instead. Only the HTML
+        // document is rewritten; every other asset and status is piped through.
+        const isHtml = (proxyRes.headers['content-type'] || '').includes('text/html');
+        if (!isHtml) {
+            if (proxyRes.statusCode) {
+                res.writeHead(proxyRes.statusCode, proxyRes.headers);
+            }
+            proxyRes.pipe(res);
+            return;
         }
-        proxyRes.pipe(res);
+
+        const chunks: Buffer[] = [];
+        proxyRes.on('data', (chunk: Buffer) => chunks.push(chunk));
+        proxyRes.on('end', () => {
+            const html = injectTerminalReconnectScript(Buffer.concat(chunks).toString('utf8'));
+            const outHeaders = { ...proxyRes.headers };
+            // The body length changed and is now fixed: drop any stale length/
+            // encoding framing and set the real one.
+            delete outHeaders['content-encoding'];
+            delete outHeaders['transfer-encoding'];
+            outHeaders['content-length'] = Buffer.byteLength(html).toString();
+            res.writeHead(proxyRes.statusCode || 200, outHeaders);
+            res.end(html);
+        });
+        proxyRes.on('error', (err) => {
+            log.error('Shell proxy response error', { error: err.message });
+            if (!res.headersSent) res.status(502).type('text/plain').send('Shell proxy error');
+        });
     });
 
     proxyReq.on('error', (err) => {

--- a/sandbox/src/templates/shell.ts
+++ b/sandbox/src/templates/shell.ts
@@ -111,3 +111,95 @@ if [ -z "$SANDBOX_WELCOME_SHOWN" ] && [ -f /app/welcome.sh ]; then
     bash /app/welcome.sh
 fi
 `;
+
+/**
+ * Message shown when the terminal WebSocket drops but a reconnect may still work
+ * (replaces ttyd's bare "Press ⏎ to Reconnect").
+ */
+export const TERMINAL_DISCONNECT_MESSAGE = 'Connection lost — press ⏎ to reconnect';
+
+/**
+ * Message shown when a reconnect attempt fails — the Actor run has most likely
+ * stopped (idle timeout, abort, run timeout, migration). Pressing ⏎ still retries.
+ */
+export const TERMINAL_FINISHED_MESSAGE = 'Actor probably finished — press ⏎ to retry';
+
+/**
+ * Browser script injected into ttyd's terminal page to explain *why* the session
+ * ended, client-side.
+ *
+ * Why client-side: the terminal is proxied (browser ↔ Actor ↔ ttyd), and most
+ * stops (run timeout, hard abort, platform scale-down) kill the container with a
+ * signal — there is no advance Actor event and no time to flush a banner before
+ * the process dies. The browser, however, can always see the socket drop and any
+ * failed reconnect, so we relabel ttyd's own reconnect overlay here.
+ *
+ * ttyd (1.7.7) drives a single overlay <div> via `overlayAddon.showOverlay(text)`
+ * (html/src/components/terminal/xterm/index.ts). On a drop it shows
+ * "Press ⏎ to Reconnect"; a retry shows "Reconnecting..."; a fresh connection
+ * shows "Reconnected". We watch those exact strings: the first prompt means the
+ * link dropped (recoverable), but a prompt that follows a "Reconnecting..." means
+ * the retry failed — so the Actor is probably gone. The relabel is cosmetic;
+ * ttyd's Enter-to-reconnect handler stays intact, so retry still works.
+ */
+export const RECONNECT_OVERLAY_SCRIPT = `(function () {
+    var LOST = ${JSON.stringify(TERMINAL_DISCONNECT_MESSAGE)};
+    var FINISHED = ${JSON.stringify(TERMINAL_FINISHED_MESSAGE)};
+
+    // ttyd's exact overlay strings; \\u23ce is the ⏎ glyph it uses.
+    var PRESS_ENTER = 'Press \\u23ce to Reconnect';
+    var RECONNECTING = 'Reconnecting...';
+    var RECONNECTED = 'Reconnected';
+
+    // True once a reconnect has been attempted since the last live connection. If
+    // we then fall back to the reconnect prompt, the attempt failed.
+    var triedReconnect = false;
+
+    function relabel(el) {
+        var text = el.textContent;
+        if (text === RECONNECTING) {
+            triedReconnect = true;
+        } else if (text === RECONNECTED) {
+            triedReconnect = false;
+        } else if (text === PRESS_ENTER) {
+            var msg = triedReconnect ? FINISHED : LOST;
+            triedReconnect = false;
+            if (el.textContent !== msg) el.textContent = msg;
+        }
+    }
+
+    // The overlay text is set via textContent, so a change shows up as a childList
+    // mutation on the overlay element (or as the element being (re)attached).
+    function elementOf(node) {
+        if (!node) return null;
+        return node.nodeType === 3 ? node.parentNode : node;
+    }
+
+    var observer = new MutationObserver(function (records) {
+        for (var i = 0; i < records.length; i++) {
+            var r = records[i];
+            var target = elementOf(r.target);
+            if (target && target.nodeType === 1) relabel(target);
+            for (var j = 0; j < r.addedNodes.length; j++) {
+                var added = elementOf(r.addedNodes[j]);
+                if (added && added.nodeType === 1) relabel(added);
+            }
+        }
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+})();`;
+
+/**
+ * Inject the reconnect-overlay script into ttyd's HTML page. The script only
+ * reacts to overlay text that appears long after load, so placement isn't
+ * critical — prefer right after <head>, falling back to <body>, then end of doc.
+ *
+ * @param html - The HTML document served by ttyd.
+ * @returns The HTML with the script injected.
+ */
+export const injectTerminalReconnectScript = (html: string): string => {
+    const tag = `<script>${RECONNECT_OVERLAY_SCRIPT}</script>`;
+    if (/<head[^>]*>/i.test(html)) return html.replace(/<head[^>]*>/i, (match) => match + tag);
+    if (/<body[^>]*>/i.test(html)) return html.replace(/<body[^>]*>/i, (match) => match + tag);
+    return html + tag;
+};

--- a/sandbox/tests/unit/shell.test.ts
+++ b/sandbox/tests/unit/shell.test.ts
@@ -1,0 +1,60 @@
+/* eslint-disable @typescript-eslint/no-floating-promises -- node:test's describe/it return promises by design */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+    injectTerminalReconnectScript,
+    RECONNECT_OVERLAY_SCRIPT,
+    TERMINAL_DISCONNECT_MESSAGE,
+    TERMINAL_FINISHED_MESSAGE,
+} from '../../src/templates/shell.js';
+
+describe('injectTerminalReconnectScript', () => {
+    it('injects the script right after <head>', () => {
+        const html = '<html><head><title>ttyd</title></head><body></body></html>';
+        const out = injectTerminalReconnectScript(html);
+        assert.match(out, /<head><script>[\s\S]*<\/script><title>/);
+        assert.ok(out.includes(RECONNECT_OVERLAY_SCRIPT));
+    });
+
+    it('preserves attributes on the <head> tag', () => {
+        const out = injectTerminalReconnectScript('<head lang="en"><meta></head>');
+        assert.ok(out.includes('<head lang="en"><script>'));
+    });
+
+    it('falls back to after <body> when there is no <head>', () => {
+        const out = injectTerminalReconnectScript('<html><body>x</body></html>');
+        assert.match(out, /<body><script>[\s\S]*<\/script>x/);
+    });
+
+    it('appends the script when there is neither <head> nor <body>', () => {
+        const out = injectTerminalReconnectScript('<p>hi</p>');
+        assert.ok(out.startsWith('<p>hi</p><script>'));
+        assert.ok(out.trimEnd().endsWith('</script>'));
+    });
+
+    it('injects only once (single <head> match)', () => {
+        const out = injectTerminalReconnectScript('<head></head><head></head>');
+        assert.equal(out.match(/<script>/g)?.length, 1);
+    });
+});
+
+describe('RECONNECT_OVERLAY_SCRIPT', () => {
+    it('carries both user-facing messages', () => {
+        assert.ok(RECONNECT_OVERLAY_SCRIPT.includes(TERMINAL_DISCONNECT_MESSAGE));
+        assert.ok(RECONNECT_OVERLAY_SCRIPT.includes(TERMINAL_FINISHED_MESSAGE));
+    });
+
+    it("matches ttyd's exact overlay strings so the relabel actually fires", () => {
+        // These must stay in lockstep with ttyd's frontend (xterm/index.ts). The ⏎
+        // is emitted as a \\u23ce escape in the browser script.
+        assert.ok(RECONNECT_OVERLAY_SCRIPT.includes('Press \\u23ce to Reconnect'));
+        assert.ok(RECONNECT_OVERLAY_SCRIPT.includes("'Reconnecting...'"));
+        assert.ok(RECONNECT_OVERLAY_SCRIPT.includes("'Reconnected'"));
+    });
+
+    it('observes the document for overlay text changes', () => {
+        assert.ok(RECONNECT_OVERLAY_SCRIPT.includes('MutationObserver'));
+        assert.ok(RECONNECT_OVERLAY_SCRIPT.includes('childList: true'));
+    });
+});


### PR DESCRIPTION
- The old server-side banner couldn't catch the common stops: the Apify SDK installs no `SIGTERM`/`SIGINT` handlers (it's driven by the platform events WebSocket), so the signal-guarded listener never attached — run timeouts, hard aborts and scale-downs showed nothing. A dying process can't reliably flush a banner either.
- Replace it with a small script injected into ttyd's page that relabels ttyd's own reconnect overlay in the browser, where every disconnect is observable: "Connection lost — press ⏎ to reconnect", and "Actor probably finished" once a retry fails. Cosmetic only — ttyd's Enter-to-reconnect still works.
- With the overlay covering every stop, remove the now-redundant server-side machinery (`shutdown.ts`, the direct-socket writes, the `migrating`/`aborting`/idle banners); the idle timeout just calls `Actor.exit`.