### PR TITLE
Stream init script output live with progress heartbeat

### DIFF
--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -399,6 +399,7 @@ Provide a bash script via the "Initialization Script" input to customize the san
 - Runs **after** library installation
 - Executes in `/sandbox` directory
 - Can install system packages, create directories, set permissions, etc.
+- Output is streamed live to the Actor log (tagged `[init]`), with a progress heartbeat for long steps, so you can follow along and debug failures
 - Errors are logged but don't prevent Actor from starting
 - **Note:** Init scripts have a 5-minute execution timeout
 

--- a/sandbox/src/consts.ts
+++ b/sandbox/src/consts.ts
@@ -38,6 +38,12 @@ export const PYTHON_BIN_DIR = '/sandbox/py/venv/bin';
 export const INIT_SCRIPT_TIMEOUT = 300000;
 
 /**
+ * How often to log a heartbeat while the init script is running (30 seconds),
+ * so long, quiet steps (e.g. `npm install`) don't look like a hang.
+ */
+export const INIT_SCRIPT_HEARTBEAT_INTERVAL = 30000;
+
+/**
  * Migration persistence constants
  */
 

--- a/sandbox/src/consts.ts
+++ b/sandbox/src/consts.ts
@@ -41,7 +41,7 @@ export const INIT_SCRIPT_TIMEOUT = 300000;
  * How often to log a heartbeat while the init script is running (30 seconds),
  * so long, quiet steps (e.g. `npm install`) don't look like a hang.
  */
-export const INIT_SCRIPT_HEARTBEAT_INTERVAL = 30000;
+export const INIT_SCRIPT_HEARTBEAT_INTERVAL_MS = 30000;
 
 /**
  * Migration persistence constants

--- a/sandbox/src/consts.ts
+++ b/sandbox/src/consts.ts
@@ -35,7 +35,7 @@ export const PYTHON_BIN_DIR = '/sandbox/py/venv/bin';
 /**
  * Init script execution timeout (5 minutes)
  */
-export const INIT_SCRIPT_TIMEOUT = 300000;
+export const INIT_SCRIPT_TIMEOUT_MS = 300000;
 
 /**
  * How often to log a heartbeat while the init script is running (30 seconds),

--- a/sandbox/src/environment.ts
+++ b/sandbox/src/environment.ts
@@ -1,12 +1,18 @@
 // Environment setup for code execution (Node.js and Python)
-import { exec } from 'node:child_process';
+import { exec, spawn } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { promisify } from 'node:util';
 
 import { log } from 'apify';
 
-import { INIT_SCRIPT_TIMEOUT, JS_TS_CODE_DIR, PYTHON_CODE_DIR, SANDBOX_DIR } from './consts.js';
+import {
+    INIT_SCRIPT_HEARTBEAT_INTERVAL,
+    INIT_SCRIPT_TIMEOUT,
+    JS_TS_CODE_DIR,
+    PYTHON_CODE_DIR,
+    SANDBOX_DIR,
+} from './consts.js';
 
 const execAsync = promisify(exec);
 
@@ -426,6 +432,102 @@ export const getExecutionEnvironment = (): NodeJS.ProcessEnv => {
 };
 
 /**
+ * Buffers a text stream and forwards it to the log one complete line at a time,
+ * each tagged with the given prefix. Partial lines are held until the newline
+ * arrives; call flush() at the end to emit any trailing text.
+ */
+const createLineStreamer = (prefix: string) => {
+    let buffer = '';
+    return {
+        push(text: string): void {
+            buffer += text;
+            const lines = buffer.split('\n');
+            buffer = lines.pop() ?? '';
+            for (const line of lines) {
+                log.info(`${prefix} ${line}`);
+            }
+        },
+        flush(): void {
+            if (buffer.length > 0) {
+                log.info(`${prefix} ${buffer}`);
+                buffer = '';
+            }
+        },
+    };
+};
+
+/**
+ * Run a bash script, streaming its stdout/stderr to the log line-by-line as it
+ * runs so progress is visible and failures are easy to pinpoint (instead of one
+ * silent gap followed by a dump at the end). A heartbeat is logged periodically
+ * so long, quiet steps (e.g. `npm install`) don't look like a hang. The full
+ * output is still collected and returned for programmatic callers.
+ */
+const runScriptStreaming = async (
+    scriptPath: string,
+): Promise<{ stdout: string; stderr: string; exitCode: number | null; timedOut: boolean }> => {
+    return new Promise((resolve) => {
+        const child = spawn('bash', [scriptPath], {
+            cwd: SANDBOX_DIR,
+            env: getExecutionEnvironment(),
+        });
+
+        let stdout = '';
+        let stderr = '';
+        let timedOut = false;
+        let settled = false;
+
+        // stderr is streamed at info level too: tools like npm/apt/git write
+        // normal progress there, so the exit code (not the stream) decides
+        // success. Output is tagged so it's distinguishable from harness logs.
+        const stdoutStreamer = createLineStreamer('[init]');
+        const stderrStreamer = createLineStreamer('[init]');
+
+        child.stdout?.on('data', (chunk: Buffer) => {
+            const text = chunk.toString();
+            stdout += text;
+            stdoutStreamer.push(text);
+        });
+        child.stderr?.on('data', (chunk: Buffer) => {
+            const text = chunk.toString();
+            stderr += text;
+            stderrStreamer.push(text);
+        });
+
+        const startedAt = Date.now();
+        const heartbeat = setInterval(() => {
+            log.info('Init script still running...', {
+                elapsedSeconds: Math.round((Date.now() - startedAt) / 1000),
+            });
+        }, INIT_SCRIPT_HEARTBEAT_INTERVAL);
+
+        // spawn() has no built-in rejection on timeout (unlike the old exec
+        // call), so enforce it here and kill the process if it overruns.
+        const timer = setTimeout(() => {
+            timedOut = true;
+            child.kill('SIGKILL');
+        }, INIT_SCRIPT_TIMEOUT);
+
+        const finish = (exitCode: number | null): void => {
+            if (settled) return;
+            settled = true;
+            clearInterval(heartbeat);
+            clearTimeout(timer);
+            stdoutStreamer.flush();
+            stderrStreamer.flush();
+            resolve({ stdout, stderr, exitCode, timedOut });
+        };
+
+        // 'error' fires when bash itself can't be spawned (no 'close' follows).
+        child.on('error', (err) => {
+            stderr += err.message;
+            finish(1);
+        });
+        child.on('close', (code) => finish(code));
+    });
+};
+
+/**
  * Execute initialization bash script
  * Runs custom bash script in /sandbox directory to setup environment
  * In local mode (MODE=local), skips script execution
@@ -478,49 +580,48 @@ export const executeInitScript = async (
 
         log.debug('Init script written to temp file', { path: tempFile });
 
-        // Execute script
-        const execOptions: { cwd?: string; timeout?: number; env?: NodeJS.ProcessEnv } = {
-            cwd: SANDBOX_DIR,
-            timeout: INIT_SCRIPT_TIMEOUT,
-            env: getExecutionEnvironment(),
-        };
+        // Execute the script, streaming output live so progress is visible and
+        // failures are easy to locate (rather than dumping everything at the end).
+        const startedAt = Date.now();
+        const { stdout, stderr, exitCode, timedOut } = await runScriptStreaming(tempFile);
+        const elapsedSeconds = ((Date.now() - startedAt) / 1000).toFixed(1);
 
-        const { stdout, stderr } = await execAsync(`bash ${tempFile}`, execOptions);
+        if (timedOut) {
+            log.error('Init script timed out', {
+                timeoutSeconds: INIT_SCRIPT_TIMEOUT / 1000,
+                elapsedSeconds,
+            });
+            return {
+                success: false,
+                stdout,
+                stderr: stderr || `Init script timed out after ${INIT_SCRIPT_TIMEOUT / 1000}s`,
+                exitCode: exitCode ?? 1,
+            };
+        }
 
-        log.info('Init script execution completed');
-        log.info('-----------------------------------------');
-        log.info(stdout || '(no output)');
-        if (stderr) {
-            log.warning(stderr);
+        if (exitCode === 0) {
+            log.info('Init script execution completed', { elapsedSeconds });
+            return { success: true, stdout, stderr, exitCode: 0 };
         }
-        log.info('-----------------------------------------');
 
-        return {
-            success: true,
-            stdout,
-            stderr,
-            exitCode: 0,
-        };
-    } catch (error) {
-        const err = error as { message: string; stdout?: string; stderr?: string; code?: number };
-        log.error('Init script execution failed', { exitCode: err.code || 1 });
-        log.error('-----------------------------------------');
-        if (err.stdout) {
-            log.error(err.stdout);
-        }
-        if (err.stderr) {
-            log.error(err.stderr);
-        }
-        if (!err.stdout && !err.stderr) {
-            log.error(err.message);
-        }
-        log.error('-----------------------------------------');
-
+        // Output was already streamed live above, so just summarise the failure.
+        log.error('Init script execution failed', { exitCode, elapsedSeconds });
         return {
             success: false,
-            stdout: err.stdout || '',
-            stderr: err.stderr || err.message || 'Init script execution failed',
-            exitCode: err.code || 1,
+            stdout,
+            stderr: stderr || 'Init script execution failed',
+            exitCode: exitCode ?? 1,
+        };
+    } catch (error) {
+        // Reaches here only if setup (e.g. writing the temp file) fails; the
+        // script run itself reports failures via its exit code above.
+        const err = error as Error;
+        log.error('Failed to run init script', { error: err.message });
+        return {
+            success: false,
+            stdout: '',
+            stderr: err.message || 'Failed to run init script',
+            exitCode: 1,
         };
     } finally {
         // Clean up temporary files

--- a/sandbox/src/environment.ts
+++ b/sandbox/src/environment.ts
@@ -7,7 +7,7 @@ import { promisify } from 'node:util';
 import { log } from 'apify';
 
 import {
-    INIT_SCRIPT_HEARTBEAT_INTERVAL,
+    INIT_SCRIPT_HEARTBEAT_INTERVAL_MS,
     INIT_SCRIPT_TIMEOUT,
     JS_TS_CODE_DIR,
     PYTHON_CODE_DIR,
@@ -499,7 +499,7 @@ const runScriptStreaming = async (
             log.info('Init script still running...', {
                 elapsedSeconds: Math.round((Date.now() - startedAt) / 1000),
             });
-        }, INIT_SCRIPT_HEARTBEAT_INTERVAL);
+        }, INIT_SCRIPT_HEARTBEAT_INTERVAL_MS);
 
         // spawn() has no built-in rejection on timeout (unlike the old exec
         // call), so enforce it here and kill the process if it overruns.

--- a/sandbox/src/environment.ts
+++ b/sandbox/src/environment.ts
@@ -8,7 +8,7 @@ import { log } from 'apify';
 
 import {
     INIT_SCRIPT_HEARTBEAT_INTERVAL_MS,
-    INIT_SCRIPT_TIMEOUT,
+    INIT_SCRIPT_TIMEOUT_MS,
     JS_TS_CODE_DIR,
     PYTHON_CODE_DIR,
     SANDBOX_DIR,
@@ -506,7 +506,7 @@ const runScriptStreaming = async (
         const timer = setTimeout(() => {
             timedOut = true;
             child.kill('SIGKILL');
-        }, INIT_SCRIPT_TIMEOUT);
+        }, INIT_SCRIPT_TIMEOUT_MS);
 
         const finish = (exitCode: number | null): void => {
             if (settled) return;
@@ -588,13 +588,13 @@ export const executeInitScript = async (
 
         if (timedOut) {
             log.error('Init script timed out', {
-                timeoutSeconds: INIT_SCRIPT_TIMEOUT / 1000,
+                timeoutSeconds: INIT_SCRIPT_TIMEOUT_MS / 1000,
                 elapsedSeconds,
             });
             return {
                 success: false,
                 stdout,
-                stderr: stderr || `Init script timed out after ${INIT_SCRIPT_TIMEOUT / 1000}s`,
+                stderr: stderr || `Init script timed out after ${INIT_SCRIPT_TIMEOUT_MS / 1000}s`,
                 exitCode: exitCode ?? 1,
             };
         }

--- a/sandbox/src/main.ts
+++ b/sandbox/src/main.ts
@@ -147,11 +147,8 @@ if (input?.initShellScript && input.initShellScript.trim().length > 0) {
     log.info('Executing init script...');
     const initResult = await executeInitScript(input.initShellScript);
     if (initResult.exitCode !== 0) {
-        log.error('Init script failed', {
-            exitCode: initResult.exitCode,
-            stderr: initResult.stderr,
-            stdout: initResult.stdout,
-        });
+        // The output and failure summary were already streamed by executeInitScript;
+        // record the reason so the /health endpoint can report it.
         initializationError = `Init script failed with exit code ${initResult.exitCode}`;
     }
 } else {

--- a/sandbox/tests/e2e.ts
+++ b/sandbox/tests/e2e.ts
@@ -141,7 +141,7 @@ async function waitForHealth(runId: string, timeoutSeconds = 180): Promise<strin
         `${colors.green}ℹ${colors.reset} Waiting for Actor to be ready (dependencies installing, init script running)...`,
     );
 
-    const pollInterval = 5000; // 5 seconds
+    const pollIntervalMs = 5000;
     const startTime = Date.now();
 
     // First, get the container URL
@@ -218,7 +218,7 @@ async function waitForHealth(runId: string, timeoutSeconds = 180): Promise<strin
         }
 
         await new Promise((resolve) => {
-            setTimeout(resolve, pollInterval);
+            setTimeout(resolve, pollIntervalMs);
         });
     }
 


### PR DESCRIPTION
Init script output was buffered and dumped only at the end, leaving a long silent gap in the log and little to debug on failure.

- Stream stdout/stderr to the log line-by-line as the script runs (tagged `[init]`)
- Log a heartbeat every 30s so long, quiet steps (e.g. `npm install`) don't look like a hang
- On failure, log the exit code and elapsed time, and flag timeouts distinctly

https://claude.ai/code/session_01HrRwkh6PiW54hbAd1YxyfQ