### PR TITLE
Auto-configure MCP servers in Claude Code, Codex, and OpenCode

### DIFF
--- a/sandbox/artifacts/AGENTS.md
+++ b/sandbox/artifacts/AGENTS.md
@@ -148,11 +148,17 @@ Access Apify platform features and thousands of Actors via `mcpc` tool.
 
 If the user picked **MCP Connectors** in the Actor input (e.g. Slack, Notion, GitHub), the sandbox writes them to `/sandbox/mcp.json` on startup. Each entry is a ready-to-use HTTP MCP proxy, authenticated with the user's credentials server-side:
 
+> **If you are Claude Code, Codex, or OpenCode**, these connectors are already registered as native MCP tools on startup — just call them directly, no `mcpc connect` needed. The steps below are for the `mcpc` CLI or any other client.
+
 ```bash
 cat /sandbox/mcp.json
 # {
 #   "mcpServers": {
-#     "conn_abc123": {
+#     "apify": {                                       # always present (hosted Apify MCP)
+#       "url": "https://mcp.apify.com",
+#       "headers": { "Authorization": "Bearer ${APIFY_TOKEN}" }
+#     },
+#     "conn_abc123": {                                 # one per user-picked Connector
 #       "url": "https://api.apify.com/v2/mcp-proxy/conn_abc123",
 #       "headers": { "Authorization": "Bearer ${APIFY_TOKEN}" }
 #     }
@@ -160,16 +166,16 @@ cat /sandbox/mcp.json
 # }
 ```
 
+`/sandbox/mcp.json` always contains the hosted Apify MCP server under the `apify` key, plus one entry per user-picked Connector.
+
 To connect with `mcpc`, read a server entry from the file and pass it to `mcpc connect`:
 
 ```bash
-# Connect to the first user-provided Connector as @user1
-URL=$(jq -r '.mcpServers | to_entries[0].value.url' /sandbox/mcp.json)
+# Connect to the first user-provided Connector (skipping the always-on "apify" entry) as @user1
+URL=$(jq -r '.mcpServers | to_entries | map(select(.key != "apify"))[0].value.url // empty' /sandbox/mcp.json)
 mcpc connect "$URL" @user1 --header "Authorization: Bearer $APIFY_TOKEN"
 mcpc @user1 tools-list --json
 ```
-
-If `/sandbox/mcp.json` has `"mcpServers": {}`, the user provided no Connectors — fall back to the Apify MCP server below.
 
 ### 🚨 CRITICAL: Connect to Apify MCP Server First
 

--- a/sandbox/src/main.ts
+++ b/sandbox/src/main.ts
@@ -13,6 +13,7 @@ import { SANDBOX_DIR } from './consts.js';
 import { parseEnvVars } from './env-vars.js';
 import { executeInitScript, setupExecutionEnvironment, setUserEnvVars } from './environment.js';
 import { createMcpServer } from './mcp.js';
+import { configureAgentMcpServers } from './mcp-agent-config.js';
 import { writeMcpConfig } from './mcp-connections.js';
 import { translateLaunchParam } from './shell-launch.js';
 import { parseNodeDependencies } from './node-deps.js';
@@ -93,9 +94,12 @@ log.info('Actor input retrieved', {
 });
 
 // Write /sandbox/mcp.json with the configured MCP Connector proxies so
-// tools like `mcpc connect` find them as soon as the shell opens.
+// tools like `mcpc connect` find them as soon as the shell opens, then load the
+// same servers into Claude Code, Codex, and OpenCode so they appear as tools the
+// moment an agent launches (no `claude mcp add` / `mcpc connect` step needed).
 if (!isLocalMode) {
-    writeMcpConfig(input?.mcpConnectors);
+    const mcpConfig = writeMcpConfig(input?.mcpConnectors);
+    configureAgentMcpServers(mcpConfig);
 }
 
 // Check for migration state and restore if available

--- a/sandbox/src/mcp-agent-config.ts
+++ b/sandbox/src/mcp-agent-config.ts
@@ -1,0 +1,281 @@
+/**
+ * MCP Agent Configuration Module
+ *
+ * Translates the user's MCP Connectors (the same list written to
+ * /sandbox/mcp.json by mcp-connections.ts) into the native config format of
+ * each pre-installed coding agent — Claude Code, Codex, and OpenCode — so the
+ * connectors are available as tools the moment the agent starts, with no
+ * `claude mcp add` / `mcpc connect` step.
+ *
+ * Why a translation step rather than pointing every agent at /sandbox/mcp.json:
+ * the three agents disagree on both the config schema and the env-var syntax.
+ *   - Claude Code: ~/.claude.json top-level `mcpServers`, entries need
+ *     `"type": "http"`, and `${VAR}` is expanded natively in header values.
+ *   - Codex: ~/.codex/config.toml `[mcp_servers.<id>]` with `url`; TOML strings
+ *     are NOT interpolated, so a bearer token is referenced by env-var NAME via
+ *     `bearer_token_env_var`. HTTP transport is gated behind the top-level
+ *     `experimental_use_rmcp_client` flag.
+ *   - OpenCode: ~/.config/opencode/opencode.json top-level `mcp`, entries use
+ *     `"type": "remote"` and the `{env:VAR}` substitution syntax.
+ *
+ * Each agent's existing config (onboarding flags, provider/model defaults,
+ * approval policy) is preserved — we only add/replace the MCP server entries.
+ * All writes log and swallow errors so a failure never aborts sandbox startup.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { log } from 'apify';
+
+import type { McpConfig, McpServerEntry } from './mcp-connections.js';
+
+const HOME = homedir();
+
+/** Config file each agent reads its MCP servers from (all under the user's home). */
+export const CLAUDE_CONFIG_PATH = join(HOME, '.claude.json');
+export const CODEX_CONFIG_PATH = join(HOME, '.codex', 'config.toml');
+export const OPENCODE_CONFIG_PATH = join(HOME, '.config', 'opencode', 'opencode.json');
+
+/** Markers around the Codex block we own, so re-runs replace rather than duplicate it. */
+const CODEX_BLOCK_START = '# >>> apify mcp connectors (auto-generated) >>>';
+const CODEX_BLOCK_END = '# <<< apify mcp connectors (auto-generated) <<<';
+
+// ---------------------------------------------------------------------------
+// Claude Code — ~/.claude.json top-level `mcpServers`
+// ---------------------------------------------------------------------------
+
+export interface ClaudeHttpServer {
+    type: 'http';
+    url: string;
+    headers: Record<string, string>;
+}
+
+/**
+ * Build Claude Code's `mcpServers` map. Claude expands `${VAR}` in header
+ * values itself, so the entries are used verbatim apart from the required
+ * `"type": "http"` discriminator.
+ */
+export const buildClaudeMcpServers = (config: McpConfig): Record<string, ClaudeHttpServer> => {
+    const servers: Record<string, ClaudeHttpServer> = {};
+    for (const [key, entry] of Object.entries(config.mcpServers)) {
+        servers[key] = { type: 'http', url: entry.url, headers: { ...entry.headers } };
+    }
+    return servers;
+};
+
+/**
+ * Merge the MCP servers into an existing parsed ~/.claude.json object, leaving
+ * every other key (e.g. `hasCompletedOnboarding`) untouched.
+ */
+export const mergeClaudeConfig = (existing: Record<string, unknown>, config: McpConfig): Record<string, unknown> => {
+    const prior = (existing.mcpServers as Record<string, unknown>) ?? {};
+    return { ...existing, mcpServers: { ...prior, ...buildClaudeMcpServers(config) } };
+};
+
+// ---------------------------------------------------------------------------
+// OpenCode — ~/.config/opencode/opencode.json top-level `mcp`
+// ---------------------------------------------------------------------------
+
+export interface OpenCodeRemoteServer {
+    type: 'remote';
+    url: string;
+    enabled: true;
+    /** Disable OAuth discovery so the static Authorization header is used as-is. */
+    oauth: false;
+    headers: Record<string, string>;
+}
+
+/** Rewrite shell-style `${VAR}` references into OpenCode's `{env:VAR}` syntax. */
+export const toOpenCodeEnvSyntax = (value: string): string =>
+    value.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, '{env:$1}');
+
+/**
+ * Build OpenCode's `mcp` map. Each connector becomes a remote server with
+ * header values converted to `{env:VAR}` so OpenCode resolves the token at
+ * launch time.
+ */
+export const buildOpenCodeMcp = (config: McpConfig): Record<string, OpenCodeRemoteServer> => {
+    const servers: Record<string, OpenCodeRemoteServer> = {};
+    for (const [key, entry] of Object.entries(config.mcpServers)) {
+        const headers: Record<string, string> = {};
+        for (const [name, val] of Object.entries(entry.headers)) {
+            headers[name] = toOpenCodeEnvSyntax(val);
+        }
+        servers[key] = { type: 'remote', url: entry.url, enabled: true, oauth: false, headers };
+    }
+    return servers;
+};
+
+/** Merge the MCP servers into an existing parsed opencode.json, preserving provider/model config. */
+export const mergeOpenCodeConfig = (existing: Record<string, unknown>, config: McpConfig): Record<string, unknown> => {
+    const prior = (existing.mcp as Record<string, unknown>) ?? {};
+    return { ...existing, mcp: { ...prior, ...buildOpenCodeMcp(config) } };
+};
+
+// ---------------------------------------------------------------------------
+// Codex — ~/.codex/config.toml `[mcp_servers.<id>]`
+// ---------------------------------------------------------------------------
+
+/** Quote a value as a TOML basic string, escaping backslashes and double quotes. */
+const tomlString = (value: string): string => `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+
+/** Match a bearer token whose entire value is a single `${VAR}` reference. */
+const BEARER_ENV_REF = /^Bearer \$\{([A-Za-z_][A-Za-z0-9_]*)\}$/;
+/** Match a header whose entire value is a single `${VAR}` reference. */
+const WHOLE_ENV_REF = /^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$/;
+
+/**
+ * Render one Codex `[mcp_servers.<key>]` table. Codex does not interpolate env
+ * vars in TOML strings, so it exposes dedicated keys that take an env-var NAME:
+ *   - an `Authorization: Bearer ${VAR}` header maps to `bearer_token_env_var`,
+ *   - any other whole-value `${VAR}` header maps to `env_http_headers`,
+ *   - anything else is written literally under `http_headers`.
+ * The connector list only ever produces the bearer case, but the fallbacks keep
+ * the translation faithful for any header shape.
+ */
+const codexServerTable = (key: string, entry: McpServerEntry): string => {
+    const lines = [`[mcp_servers.${key}]`, `url = ${tomlString(entry.url)}`];
+
+    let bearerEnvVar: string | undefined;
+    const envHeaders: [string, string][] = [];
+    const literalHeaders: [string, string][] = [];
+
+    for (const [name, value] of Object.entries(entry.headers)) {
+        const bearer = name.toLowerCase() === 'authorization' ? BEARER_ENV_REF.exec(value) : null;
+        const whole = WHOLE_ENV_REF.exec(value);
+        if (bearer) {
+            bearerEnvVar = bearer[1];
+        } else if (whole) {
+            envHeaders.push([name, whole[1]]);
+        } else {
+            literalHeaders.push([name, value]);
+        }
+    }
+
+    if (bearerEnvVar) lines.push(`bearer_token_env_var = ${tomlString(bearerEnvVar)}`);
+    if (literalHeaders.length > 0) {
+        const inline = literalHeaders.map(([n, v]) => `${tomlString(n)} = ${tomlString(v)}`).join(', ');
+        lines.push(`http_headers = { ${inline} }`);
+    }
+    if (envHeaders.length > 0) {
+        const inline = envHeaders.map(([n, v]) => `${tomlString(n)} = ${tomlString(v)}`).join(', ');
+        lines.push(`env_http_headers = { ${inline} }`);
+    }
+    // Remote servers reach Codex through a proxy that may cold-start; the 10s
+    // default startup timeout is tight, so give the handshake more room.
+    lines.push('startup_timeout_sec = 20');
+
+    return lines.join('\n');
+};
+
+/** Build the marker-delimited Codex block holding every connector's server table. */
+export const buildCodexBlock = (config: McpConfig): string => {
+    const tables = Object.entries(config.mcpServers).map(([key, entry]) => codexServerTable(key, entry));
+    return [CODEX_BLOCK_START, ...tables, CODEX_BLOCK_END].join('\n\n');
+};
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Splice the connector block into existing config.toml text. Replaces a prior
+ * auto-generated block if present (idempotent across restarts/migrations), and
+ * ensures the top-level `experimental_use_rmcp_client` flag that gates HTTP MCP
+ * transport is set — prepended so it stays ahead of any `[table]` headers, as
+ * TOML requires of bare top-level keys.
+ */
+export const applyCodexConfig = (existing: string, config: McpConfig): string => {
+    // Drop any block we wrote previously, plus the blank lines hugging it.
+    const blockPattern = new RegExp(
+        `\\n*${escapeRegExp(CODEX_BLOCK_START)}[\\s\\S]*?${escapeRegExp(CODEX_BLOCK_END)}\\n*`,
+    );
+    let text = existing.replace(blockPattern, '\n').replace(/\s+$/, '');
+
+    if (!/^\s*experimental_use_rmcp_client\s*=/m.test(text)) {
+        text = `experimental_use_rmcp_client = true\n${text}`;
+    }
+
+    return `${text}\n\n${buildCodexBlock(config)}\n`;
+};
+
+// ---------------------------------------------------------------------------
+// Side effects: read each agent's config, merge in the connectors, write it back
+// ---------------------------------------------------------------------------
+
+/** Read and JSON-parse a config file. Returns `{}` if absent, `null` if unreadable/corrupt. */
+const readJsonConfig = (path: string): Record<string, unknown> | null => {
+    if (!existsSync(path)) return {};
+    try {
+        const parsed = JSON.parse(readFileSync(path, 'utf8'));
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            log.warning('Existing agent config is not a JSON object; leaving it unchanged', { path });
+            return null;
+        }
+        return parsed as Record<string, unknown>;
+    } catch (error) {
+        // Don't clobber a config we can't understand — better to keep the
+        // working baked-in defaults than overwrite them with a partial file.
+        log.warning('Failed to parse existing agent config; leaving it unchanged', {
+            path,
+            error: (error as Error).message,
+        });
+        return null;
+    }
+};
+
+const writeFileEnsuringDir = (path: string, contents: string): void => {
+    const dir = dirname(path);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    writeFileSync(path, contents);
+};
+
+const configureClaude = (config: McpConfig): void => {
+    const existing = readJsonConfig(CLAUDE_CONFIG_PATH);
+    if (!existing) return;
+    const merged = mergeClaudeConfig(existing, config);
+    writeFileEnsuringDir(CLAUDE_CONFIG_PATH, `${JSON.stringify(merged, null, 2)}\n`);
+};
+
+const configureOpenCode = (config: McpConfig): void => {
+    const existing = readJsonConfig(OPENCODE_CONFIG_PATH);
+    if (!existing) return;
+    const merged = mergeOpenCodeConfig(existing, config);
+    writeFileEnsuringDir(OPENCODE_CONFIG_PATH, `${JSON.stringify(merged, null, 2)}\n`);
+};
+
+const configureCodex = (config: McpConfig): void => {
+    const existing = existsSync(CODEX_CONFIG_PATH) ? readFileSync(CODEX_CONFIG_PATH, 'utf8') : '';
+    writeFileEnsuringDir(CODEX_CONFIG_PATH, applyCodexConfig(existing, config));
+};
+
+/**
+ * Load the user's MCP Connectors into Claude Code, Codex, and OpenCode so they
+ * appear as tools on launch. No-op when no connectors are configured (the
+ * agents keep their baked-in defaults). Each agent is configured independently
+ * and failures are logged but never thrown.
+ */
+export const configureAgentMcpServers = (config: McpConfig): void => {
+    const count = Object.keys(config.mcpServers).length;
+    if (count === 0) {
+        log.debug('No MCP connectors configured; leaving agent configs untouched');
+        return;
+    }
+
+    const agents: [string, (config: McpConfig) => void][] = [
+        ['Claude Code', configureClaude],
+        ['Codex', configureCodex],
+        ['OpenCode', configureOpenCode],
+    ];
+
+    for (const [name, configure] of agents) {
+        try {
+            configure(config);
+            log.info(`Configured ${name} with MCP connectors`, { count });
+        } catch (error) {
+            log.error(`Failed to configure ${name} with MCP connectors`, {
+                error: (error as Error).message,
+            });
+        }
+    }
+};

--- a/sandbox/src/mcp-connections.ts
+++ b/sandbox/src/mcp-connections.ts
@@ -20,6 +20,9 @@ import { SANDBOX_DIR } from './consts.js';
 
 export const MCP_CONFIG_PATH = `${SANDBOX_DIR}/mcp.json`;
 
+/** Apify's hosted MCP server, always available via the run's APIFY_TOKEN. */
+export const APIFY_MCP_URL = 'https://mcp.apify.com';
+
 export interface McpServerEntry {
     url: string;
     headers: Record<string, string>;
@@ -28,6 +31,12 @@ export interface McpServerEntry {
 export interface McpConfig {
     mcpServers: Record<string, McpServerEntry>;
 }
+
+/** The always-on Apify MCP server entry seeded into every config. */
+const apifyMcpServer = (): McpServerEntry => ({
+    url: APIFY_MCP_URL,
+    headers: { Authorization: 'Bearer ${APIFY_TOKEN}' },
+});
 
 /**
  * Sanitize a Connector ID for use as a JSON object key. We keep the ID as the
@@ -41,14 +50,14 @@ const toServerKey = (id: string): string => {
 
 /**
  * Build the MCP config object from a list of Connector IDs.
- * Returns `{ mcpServers: {} }` when the input is empty/invalid so the file
- * is still a valid, well-known shape downstream tools can read.
+ *
+ * Always seeds the hosted Apify MCP server (key `apify`) so agents have it
+ * available out of the box, then appends one entry per user-provided Connector.
+ * Returns just the Apify entry when the input is empty/invalid, so the file is
+ * never empty and downstream tools can rely on its shape.
  */
-export const buildMcpConfig = (
-    connectionIds: string[] | undefined,
-    proxyUrl: string | undefined,
-): McpConfig => {
-    const config: McpConfig = { mcpServers: {} };
+export const buildMcpConfig = (connectionIds: string[] | undefined, proxyUrl: string | undefined): McpConfig => {
+    const config: McpConfig = { mcpServers: { apify: apifyMcpServer() } };
 
     if (!connectionIds || connectionIds.length === 0) return config;
 
@@ -75,12 +84,17 @@ export const buildMcpConfig = (
  * Write the MCP config to /sandbox/mcp.json. Always writes a file (even when
  * the connection list is empty) so consumers can rely on its presence.
  * Logs and swallows errors — a failed write must not abort sandbox startup.
+ *
+ * Returns the config it built so the caller can hand the same server list to
+ * the agent configurators (see mcp-agent-config.ts) without rebuilding it. The
+ * config is returned even if the write fails, since the agent configs are
+ * independent of the /sandbox/mcp.json file.
  */
-export const writeMcpConfig = (connectionIds: string[] | undefined): void => {
-    try {
-        const proxyUrl = process.env.APIFY_MCP_PROXY_URL;
-        const config = buildMcpConfig(connectionIds, proxyUrl);
+export const writeMcpConfig = (connectionIds: string[] | undefined): McpConfig => {
+    const proxyUrl = process.env.APIFY_MCP_PROXY_URL;
+    const config = buildMcpConfig(connectionIds, proxyUrl);
 
+    try {
         const dir = dirname(MCP_CONFIG_PATH);
         if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 
@@ -89,9 +103,7 @@ export const writeMcpConfig = (connectionIds: string[] | undefined): void => {
         const count = Object.keys(config.mcpServers).length;
         log.info('Wrote MCP connections config', { path: MCP_CONFIG_PATH, count });
         if (count > 0 && !proxyUrl) {
-            log.warning(
-                'APIFY_MCP_PROXY_URL is not set; mcp.json entries point to an empty proxy base URL',
-            );
+            log.warning('APIFY_MCP_PROXY_URL is not set; mcp.json entries point to an empty proxy base URL');
         }
     } catch (error) {
         log.error('Failed to write MCP connections config', {
@@ -99,4 +111,6 @@ export const writeMcpConfig = (connectionIds: string[] | undefined): void => {
             error: (error as Error).message,
         });
     }
+
+    return config;
 };

--- a/sandbox/tests/unit/mcp-agent-config.test.ts
+++ b/sandbox/tests/unit/mcp-agent-config.test.ts
@@ -1,0 +1,145 @@
+/* eslint-disable @typescript-eslint/no-floating-promises -- node:test's describe/it return promises by design */
+/* eslint-disable no-template-curly-in-string -- ${APIFY_TOKEN} is a literal placeholder from mcp.json, not a JS template expression */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+    applyCodexConfig,
+    buildClaudeMcpServers,
+    buildCodexBlock,
+    buildOpenCodeMcp,
+    mergeClaudeConfig,
+    mergeOpenCodeConfig,
+    toOpenCodeEnvSyntax,
+} from '../../src/mcp-agent-config.js';
+import type { McpConfig } from '../../src/mcp-connections.js';
+
+const CONFIG: McpConfig = {
+    mcpServers: {
+        conn_abc123: {
+            url: 'https://api.apify.com/v2/mcp-proxy/conn_abc123',
+            headers: { Authorization: 'Bearer ${APIFY_TOKEN}' },
+        },
+        'conn-def': {
+            url: 'https://api.apify.com/v2/mcp-proxy/conn-def',
+            headers: { Authorization: 'Bearer ${APIFY_TOKEN}' },
+        },
+    },
+};
+
+describe('buildClaudeMcpServers', () => {
+    it('adds type:http and keeps url + headers verbatim (Claude expands ${VAR} itself)', () => {
+        const servers = buildClaudeMcpServers(CONFIG);
+        assert.deepEqual(servers.conn_abc123, {
+            type: 'http',
+            url: 'https://api.apify.com/v2/mcp-proxy/conn_abc123',
+            headers: { Authorization: 'Bearer ${APIFY_TOKEN}' },
+        });
+    });
+
+    it('produces one entry per connector', () => {
+        assert.deepEqual(Object.keys(buildClaudeMcpServers(CONFIG)), ['conn_abc123', 'conn-def']);
+    });
+});
+
+describe('mergeClaudeConfig', () => {
+    it('preserves existing keys like hasCompletedOnboarding', () => {
+        const merged = mergeClaudeConfig({ hasCompletedOnboarding: true }, CONFIG);
+        assert.equal(merged.hasCompletedOnboarding, true);
+        assert.ok((merged.mcpServers as Record<string, unknown>).conn_abc123);
+    });
+
+    it('is idempotent — re-merging yields the same servers', () => {
+        const once = mergeClaudeConfig({ hasCompletedOnboarding: true }, CONFIG);
+        const twice = mergeClaudeConfig(once, CONFIG);
+        assert.deepEqual(twice, once);
+    });
+});
+
+describe('toOpenCodeEnvSyntax', () => {
+    it('rewrites ${VAR} into {env:VAR}', () => {
+        assert.equal(toOpenCodeEnvSyntax('Bearer ${APIFY_TOKEN}'), 'Bearer {env:APIFY_TOKEN}');
+    });
+
+    it('leaves strings without ${VAR} unchanged', () => {
+        assert.equal(toOpenCodeEnvSyntax('Bearer static-token'), 'Bearer static-token');
+    });
+});
+
+describe('buildOpenCodeMcp', () => {
+    it('builds remote servers with oauth:false and {env:VAR} headers', () => {
+        const mcp = buildOpenCodeMcp(CONFIG);
+        assert.deepEqual(mcp.conn_abc123, {
+            type: 'remote',
+            url: 'https://api.apify.com/v2/mcp-proxy/conn_abc123',
+            enabled: true,
+            oauth: false,
+            headers: { Authorization: 'Bearer {env:APIFY_TOKEN}' },
+        });
+    });
+});
+
+describe('mergeOpenCodeConfig', () => {
+    it('preserves provider/model config and adds the mcp block', () => {
+        const merged = mergeOpenCodeConfig(
+            { model: 'apify-openrouter/anthropic/claude-sonnet-4.5', provider: { x: 1 } },
+            CONFIG,
+        );
+        assert.equal(merged.model, 'apify-openrouter/anthropic/claude-sonnet-4.5');
+        assert.deepEqual(merged.provider, { x: 1 });
+        assert.ok((merged.mcp as Record<string, unknown>)['conn-def']);
+    });
+});
+
+describe('buildCodexBlock', () => {
+    it('emits one [mcp_servers.<id>] table per connector with url + bearer_token_env_var', () => {
+        const block = buildCodexBlock(CONFIG);
+        assert.match(block, /\[mcp_servers\.conn_abc123\]/);
+        assert.match(block, /\[mcp_servers\.conn-def\]/);
+        assert.match(block, /url = "https:\/\/api\.apify\.com\/v2\/mcp-proxy\/conn_abc123"/);
+        // The literal ${APIFY_TOKEN} must NOT leak into TOML — Codex resolves the
+        // env var by name instead.
+        assert.match(block, /bearer_token_env_var = "APIFY_TOKEN"/);
+        assert.doesNotMatch(block, /\$\{APIFY_TOKEN\}/);
+    });
+
+    it('is wrapped in the auto-generated markers', () => {
+        const block = buildCodexBlock(CONFIG);
+        assert.match(block, /# >>> apify mcp connectors \(auto-generated\) >>>/);
+        assert.match(block, /# <<< apify mcp connectors \(auto-generated\) <<</);
+    });
+});
+
+describe('applyCodexConfig', () => {
+    const BASE = 'approval_policy = "never"\nsandbox_mode = "danger-full-access"\n';
+
+    it('preserves the base config and prepends the rmcp flag before any table', () => {
+        const out = applyCodexConfig(BASE, CONFIG);
+        assert.match(out, /approval_policy = "never"/);
+        assert.match(out, /sandbox_mode = "danger-full-access"/);
+        // The flag is a bare top-level key, so it must appear before the first table.
+        const flagIdx = out.indexOf('experimental_use_rmcp_client');
+        const tableIdx = out.indexOf('[mcp_servers.');
+        assert.ok(flagIdx >= 0 && flagIdx < tableIdx, 'rmcp flag must precede the first [mcp_servers] table');
+    });
+
+    it('does not duplicate the rmcp flag when it is already present', () => {
+        const withFlag = `experimental_use_rmcp_client = true\n${BASE}`;
+        const out = applyCodexConfig(withFlag, CONFIG);
+        assert.equal(out.match(/experimental_use_rmcp_client/g)?.length, 1);
+    });
+
+    it('replaces a prior generated block instead of appending a second one (idempotent)', () => {
+        const once = applyCodexConfig(BASE, CONFIG);
+        const twice = applyCodexConfig(once, CONFIG);
+        assert.equal(twice, once);
+        assert.equal(twice.match(/# >>> apify mcp connectors/g)?.length, 1);
+    });
+
+    it('reflects a changed connector list on a re-run', () => {
+        const first = applyCodexConfig(BASE, CONFIG);
+        const second = applyCodexConfig(first, { mcpServers: { only: CONFIG.mcpServers.conn_abc123 } });
+        assert.match(second, /\[mcp_servers\.only\]/);
+        assert.doesNotMatch(second, /\[mcp_servers\.conn-def\]/);
+    });
+});

--- a/sandbox/tests/unit/mcp-connections.test.ts
+++ b/sandbox/tests/unit/mcp-connections.test.ts
@@ -3,32 +3,45 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { buildMcpConfig } from '../../src/mcp-connections.js';
+import { APIFY_MCP_URL, buildMcpConfig } from '../../src/mcp-connections.js';
 
 const PROXY = 'https://api.apify.com/v2/mcp-proxy';
 
+/** The Apify MCP server is always seeded into the config under the `apify` key. */
+const APIFY_ENTRY = { url: APIFY_MCP_URL, headers: { Authorization: 'Bearer ${APIFY_TOKEN}' } };
+
 describe('buildMcpConfig', () => {
-    describe('empty / nullish input', () => {
-        it('returns an empty mcpServers map for undefined', () => {
-            assert.deepEqual(buildMcpConfig(undefined, PROXY), { mcpServers: {} });
+    describe('always-on Apify MCP server', () => {
+        it('seeds the Apify MCP server even with no connectors', () => {
+            assert.deepEqual(buildMcpConfig(undefined, PROXY), { mcpServers: { apify: APIFY_ENTRY } });
+            assert.deepEqual(buildMcpConfig([], PROXY), { mcpServers: { apify: APIFY_ENTRY } });
         });
 
-        it('returns an empty mcpServers map for an empty array', () => {
-            assert.deepEqual(buildMcpConfig([], PROXY), { mcpServers: {} });
+        it('points the Apify entry at https://mcp.apify.com with the APIFY_TOKEN bearer', () => {
+            const { apify } = buildMcpConfig(['conn_abc'], PROXY).mcpServers;
+            assert.equal(apify.url, 'https://mcp.apify.com');
+            assert.equal(apify.headers.Authorization, 'Bearer ${APIFY_TOKEN}');
+        });
+    });
+
+    describe('empty / nullish input', () => {
+        it('returns only the Apify server for an empty array', () => {
+            assert.deepEqual(Object.keys(buildMcpConfig([], PROXY).mcpServers), ['apify']);
         });
 
         it('skips blank / non-string entries', () => {
             // @ts-expect-error - intentionally passing non-string to exercise runtime guard
             const config = buildMcpConfig(['', '   ', null, 42, 'conn_ok'], PROXY);
-            assert.deepEqual(Object.keys(config.mcpServers), ['conn_ok']);
+            assert.deepEqual(Object.keys(config.mcpServers), ['apify', 'conn_ok']);
         });
     });
 
     describe('valid Connector IDs', () => {
-        it('builds one server entry per Connector ID', () => {
+        it('builds one server entry per Connector ID (alongside the Apify server)', () => {
             const config = buildMcpConfig(['conn_abc123', 'conn_def456'], PROXY);
             assert.deepEqual(config, {
                 mcpServers: {
+                    apify: APIFY_ENTRY,
                     conn_abc123: {
                         url: `${PROXY}/conn_abc123`,
                         headers: { Authorization: 'Bearer ${APIFY_TOKEN}' },
@@ -53,7 +66,7 @@ describe('buildMcpConfig', () => {
 
         it('trims whitespace around Connector IDs', () => {
             const config = buildMcpConfig(['  conn_abc  '], PROXY);
-            assert.deepEqual(Object.keys(config.mcpServers), ['conn_abc']);
+            assert.deepEqual(Object.keys(config.mcpServers), ['apify', 'conn_abc']);
             assert.equal(config.mcpServers.conn_abc.url, `${PROXY}/conn_abc`);
         });
     });


### PR DESCRIPTION
The sandbox writes the user's MCP Connectors to `/sandbox/mcp.json`, but the bundled agents never read it — so connectors weren't usable without a manual `mcpc connect` / `claude mcp add`.

- Translate the connector list into each agent's native config at startup, handling their differing schemas and env-var syntaxes: Claude `~/.claude.json` (`type: http`, `${VAR}`), Codex `~/.codex/config.toml` (`bearer_token_env_var` + `experimental_use_rmcp_client`), OpenCode `opencode.json` (`type: remote`, `{env:VAR}`). Existing agent config is preserved and the merge is idempotent across restarts/migrations.
- Always seed the hosted Apify MCP server (`https://mcp.apify.com`, auth via `APIFY_TOKEN`) so it's present in `mcp.json` and available in all three agents out of the box.
- Add unit tests for the translation/merge logic; update `AGENTS.md` to note the bundled agents expose connectors as native tools.

https://claude.ai/code/session_01Dcz8dwbRPsgmSDq8rhS9xY