### PR TITLE
Simplify sandbox homepage and add idle-shutdown countdown

### DIFF
--- a/sandbox/src/consts.ts
+++ b/sandbox/src/consts.ts
@@ -33,6 +33,13 @@ export const PYTHON_VENV_DIR = '/sandbox/py/venv';
 export const PYTHON_BIN_DIR = '/sandbox/py/venv/bin';
 
 /**
+ * Default idle timeout in seconds (15 minutes). The container shuts down
+ * automatically after this much inactivity unless overridden via the
+ * `idleTimeoutSecs` input. Set to 0 to disable.
+ */
+export const DEFAULT_IDLE_TIMEOUT_SECS = 900;
+
+/**
  * Init script execution timeout (5 minutes)
  */
 export const INIT_SCRIPT_TIMEOUT_MS = 300000;

--- a/sandbox/src/main.ts
+++ b/sandbox/src/main.ts
@@ -9,7 +9,7 @@ import type { Request, Response } from 'express';
 import express from 'express';
 import httpProxy from 'http-proxy';
 
-import { SANDBOX_DIR } from './consts.js';
+import { DEFAULT_IDLE_TIMEOUT_SECS, SANDBOX_DIR } from './consts.js';
 import { parseEnvVars } from './env-vars.js';
 import { executeInitScript, setupExecutionEnvironment, setUserEnvVars } from './environment.js';
 import { createMcpServer } from './mcp.js';
@@ -55,6 +55,9 @@ import type { ActorInput, ProxyMapping } from './types.js';
 let initializationComplete = false;
 let initializationError: string | null = null;
 let lastActivityAt = Date.now();
+// Seconds of inactivity before auto-shutdown (0 = disabled). Set from input at
+// startup; kept module-level so the landing page and /health can report it.
+let idleTimeoutSecs = DEFAULT_IDLE_TIMEOUT_SECS;
 
 // Check if running in local mode
 const isLocalMode = process.env.MODE === 'local';
@@ -649,6 +652,7 @@ app.get('/', (_req: Request, res: Response) => {
         getLandingPageHTML({
             serverUrl,
             isLocalMode,
+            idleTimeoutSecs,
         }),
     );
 });
@@ -666,7 +670,7 @@ app.get('/browse/*path', handleBrowse);
 // LLMs.txt endpoint (Markdown documentation for LLMs)
 app.get('/llms.txt', (_req: Request, res: Response) => {
     res.setHeader('Content-Type', 'text/plain; charset=utf-8');
-    res.send(getLLMsMarkdown({ serverUrl }));
+    res.send(getLLMsMarkdown({ serverUrl, idleTimeoutSecs }));
 });
 
 // ============================================================================
@@ -774,7 +778,12 @@ app.get('/health', (_req: Request, res: Response) => {
         return;
     }
 
-    res.json({ status: 'healthy' });
+    const body: Record<string, unknown> = { status: 'healthy', idleTimeoutSecs };
+    if (idleTimeoutSecs > 0) {
+        const elapsedSecs = Math.floor((Date.now() - lastActivityAt) / 1000);
+        body.remainingSecs = Math.max(0, idleTimeoutSecs - elapsedSecs);
+    }
+    res.json(body);
 });
 
 // MCP endpoint using proper StreamableHTTPServerTransport
@@ -1443,7 +1452,7 @@ server.listen(port, () => {
     console.log('=====================================\n');
 
     // Start idle timeout check
-    const idleTimeoutSecs = input?.idleTimeoutSecs ?? 900;
+    idleTimeoutSecs = input?.idleTimeoutSecs ?? DEFAULT_IDLE_TIMEOUT_SECS;
     if (idleTimeoutSecs > 0) {
         log.info(`Idle timeout monitor started (${idleTimeoutSecs}s)`);
         setInterval(async () => {

--- a/sandbox/src/templates/landing.css
+++ b/sandbox/src/templates/landing.css
@@ -320,38 +320,6 @@ code {
     font-style: italic;
 }
 
-/* Collapsible sections */
-.collapsible-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    cursor: pointer;
-    user-select: none;
-    gap: 12px;
-}
-.collapse-btn {
-    background: var(--chip);
-    color: var(--text-muted);
-    border: 1px solid var(--border);
-    padding: 5px 11px;
-    border-radius: 6px;
-    font-size: 11.5px;
-    font-weight: 600;
-    cursor: pointer;
-}
-.collapse-btn:hover {
-    color: var(--text-strong);
-}
-.collapsible-content {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    margin-top: 2px;
-}
-.collapsible-content.collapsed {
-    display: none;
-}
-
 /* Status badge */
 .status-badge {
     display: inline-flex;
@@ -372,6 +340,10 @@ code {
     border-radius: 50%;
     background: var(--text-faint);
     animation: pulse 2s infinite;
+}
+.status-icon {
+    font-size: 12px;
+    line-height: 1;
 }
 .status-badge.healthy .status-dot {
     background: var(--ok);

--- a/sandbox/src/templates/landing.ejs
+++ b/sandbox/src/templates/landing.ejs
@@ -12,12 +12,16 @@
         <header class="hero">
             <div>
                 <h1>Apify AI Code Sandbox</h1>
-                <p class="lead">Containerized sandbox environment for AI coding operations. Connect through HTTP, MCP, or the interactive shell.</p>
+                <p class="lead">Containerized sandbox environment for AI coding operations. Connect through HTTP, MCP, or the interactive shell.<% if (idleTimeoutSecs > 0) { %> The container shuts down automatically after <%= idleTimeoutLabel %> of inactivity (configurable via the <code>idleTimeoutSecs</code> input).<% } %></p>
             </div>
             <div data-no-md style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap;">
                 <div class="status-badge loading" id="statusBadge">
                     <span class="status-dot"></span>
                     <span id="statusText">Checking...</span>
+                </div>
+                <div class="status-badge" id="shutdownBadge" style="display: none;" title="Time remaining before automatic idle shutdown">
+                    <span class="status-icon">⏻</span>
+                    <span id="shutdownText"></span>
                 </div>
                 <% if (isLocalMode) { %>
                     <div class="badge"><%= modeLabel %></div>
@@ -48,26 +52,30 @@
 
         <section class="card">
             <h2><span class="section-icon">📡</span> Connect with MCP</h2>
+            <p class="muted">No authentication required — the MCP server URL below is all you need to connect.</p>
             <h3 class="example-label">URL</h3>
             <div class="code-block-wrapper">
                 <button class="copy-btn" data-tooltip="Click to copy" onclick="copyCode(this)">Copy</button>
                 <pre class="code-block"><%= serverUrl %>/mcp</pre>
             </div>
 
-            <h3 class="example-label">Claude Code</h3>
+            <h3 class="example-label">Set up examples</h3>
             <div class="code-block-wrapper">
                 <button class="copy-btn" data-tooltip="Click to copy" onclick="copyCode(this)">Copy</button>
-                <pre class="code-block" data-lang="bash"><span class="hl-command">claude</span> <span class="hl-command">mcp</span> <span class="hl-command">add</span> <span class="hl-flag">--transport</span> http sandbox <span class="hl-url"><%= serverUrl %>/mcp</span></pre>
+                <pre class="code-block" data-lang="bash"><span class="hl-comment"># Claude Code</span>
+<span class="hl-command">claude</span> mcp add <span class="hl-flag">--transport</span> http sandbox <span class="hl-url"><%= serverUrl %>/mcp</span>
+
+<span class="hl-comment"># Codex</span>
+<span class="hl-command">codex</span> mcp add sandbox <span class="hl-flag">--url</span> <span class="hl-url"><%= serverUrl %>/mcp</span>
+
+<span class="hl-comment"># Any MCP client (mcpc)</span>
+<span class="hl-command">mcpc</span> connect <span class="hl-url"><%= serverUrl %>/mcp</span></pre>
             </div>
         </section>
 
         <section class="card">
-            <div class="collapsible-header" onclick="toggleCollapse('codeExec')">
-                <h2><span class="section-icon">⚡</span> Code execution API</h2>
-                <button class="collapse-btn" id="codeExecBtn">Hide</button>
-            </div>
+            <h2><span class="section-icon">⚡</span> Code execution API</h2>
 
-            <div class="collapsible-content" id="codeExec">
             <h3 class="example-label">Run bash command</h3>
             <div class="code-block-wrapper">
                 <button class="copy-btn" data-tooltip="Click to copy" onclick="copyCode(this)">Copy</button>
@@ -91,16 +99,30 @@
   <span class="hl-flag">-H</span> <span class="hl-string">"Content-Type: application/json"</span> \
   <span class="hl-flag">-d</span> <span class="hl-string">'{"<span class="hl-key">command</span>": "console.log(\"hello\")", "<span class="hl-key">language</span>": "ts", "<span class="hl-key">timeoutSecs</span>": <span class="hl-number">10</span>}'</span></pre>
             </div>
+
+            <h3 class="example-label">Response format</h3>
+            <p class="muted">All <code>/exec</code> requests return:</p>
+            <div class="code-block-wrapper">
+                <button class="copy-btn" data-tooltip="Click to copy" onclick="copyCode(this)">Copy</button>
+                <pre class="code-block" data-lang="json">{
+    <span class="hl-key">"stdout"</span>: <span class="hl-string">"string"</span>,
+    <span class="hl-key">"stderr"</span>: <span class="hl-string">"string"</span>,
+    <span class="hl-key">"exitCode"</span>: <span class="hl-number">0</span>,
+    <span class="hl-key">"language"</span>: <span class="hl-string">"shell|js|ts|py"</span>
+}</pre>
             </div>
+
+            <h3 class="example-label">Working directories</h3>
+            <ul class="list">
+                <li>Shell commands: <code>/sandbox</code> (default)</li>
+                <li>JavaScript/TypeScript: <code>/sandbox/js-ts</code> (default)</li>
+                <li>Python: <code>/sandbox/py</code> (default)</li>
+                <li>Override with <code>cwd</code> parameter (must be within <code>/sandbox</code>)</li>
+            </ul>
         </section>
 
         <section class="card">
-            <div class="collapsible-header" onclick="toggleCollapse('filesystem')">
-                <h2><span class="section-icon">📁</span> Filesystem API</h2>
-                <button class="collapse-btn" id="filesystemBtn">Hide</button>
-            </div>
-
-            <div class="collapsible-content" id="filesystem">
+            <h2><span class="section-icon">📁</span> Filesystem API</h2>
             <p class="muted">Direct file operations using HTTP methods. All paths relative to <code>/sandbox</code>.</p>
 
             <h3 class="example-label">Read file or list directory</h3>
@@ -141,16 +163,10 @@
                 <button class="copy-btn" data-tooltip="Click to copy" onclick="copyCode(this)">Copy</button>
                 <pre class="code-block" data-lang="bash"><span class="hl-curl">curl</span> <span class="hl-flag">-I</span> <span class="hl-url"><%= serverUrl %>/fs/data.json</span></pre>
             </div>
-            </div>
         </section>
 
         <section class="card">
-            <div class="collapsible-header" onclick="toggleCollapse('proxyConfig')">
-                <h2><span class="section-icon">🔀</span> Proxy mappings</h2>
-                <button class="collapse-btn" id="proxyConfigBtn">Hide</button>
-            </div>
-
-            <div class="collapsible-content" id="proxyConfig">
+            <h2><span class="section-icon">🔀</span> Proxy mappings</h2>
             <p class="muted">Expose web servers that you start <em>inside</em> the sandbox (your own dev server, a TUI gateway, etc.) at a public URL path on this container, so they're reachable from the browser or other services. Each mapping forwards <code>&lt;container-url&gt;/&lt;path&gt;</code> to <code>http://127.0.0.1:&lt;port&gt;/...</code> over HTTP and WebSocket. Changes apply immediately and persist across restarts.</p>
 
             <div data-no-md id="proxyMappingsList"></div>
@@ -181,57 +197,6 @@
 <span class="hl-comment"># Remove a mapping</span>
 <span class="hl-curl">curl</span> <span class="hl-flag">-X</span> <span class="hl-method">DELETE</span> <span class="hl-url"><%= serverUrl %>/proxy-config/openclaw</span></pre>
             </div>
-            </div>
-        </section>
-
-        <section class="card">
-            <div class="collapsible-header" onclick="toggleCollapse('responseFormat')">
-                <h2><span class="section-icon">📋</span> Response format</h2>
-                <button class="collapse-btn" id="responseFormatBtn">Hide</button>
-            </div>
-
-            <div class="collapsible-content" id="responseFormat">
-            <p class="muted">All <code>/exec</code> requests return:</p>
-            <div class="code-block-wrapper">
-                <button class="copy-btn" data-tooltip="Click to copy" onclick="copyCode(this)">Copy</button>
-                <pre class="code-block" data-lang="json">{
-    <span class="hl-key">"stdout"</span>: <span class="hl-string">"string"</span>,
-    <span class="hl-key">"stderr"</span>: <span class="hl-string">"string"</span>,
-    <span class="hl-key">"exitCode"</span>: <span class="hl-number">0</span>,
-    <span class="hl-key">"language"</span>: <span class="hl-string">"shell|js|ts|py"</span>
-}</pre>
-            </div>
-            </div>
-        </section>
-
-        <section class="card">
-            <div class="collapsible-header" onclick="toggleCollapse('workingDirs')">
-                <h2><span class="section-icon">📂</span> Working directories</h2>
-                <button class="collapse-btn" id="workingDirsBtn">Hide</button>
-            </div>
-
-            <div class="collapsible-content" id="workingDirs">
-            <ul class="list">
-                <li>Shell commands: <code>/sandbox</code> (default)</li>
-                <li>JavaScript/TypeScript: <code>/sandbox/js-ts</code> (default)</li>
-                <li>Python: <code>/sandbox/py</code> (default)</li>
-                <li>Override with <code>cwd</code> parameter (must be within <code>/sandbox</code>)</li>
-            </ul>
-            </div>
-        </section>
-
-        <section class="card">
-            <div class="collapsible-header" onclick="toggleCollapse('configuration')">
-                <h2><span class="section-icon">⚙️</span> Configuration</h2>
-                <button class="collapse-btn" id="configurationBtn">Hide</button>
-            </div>
-
-            <div class="collapsible-content" id="configuration">
-            <ul class="list">
-                <li><strong>Idle timeout</strong>: the container automatically shuts down after inactivity (default 10m).</li>
-                <li><strong>Execution timeout</strong>: recommended to set to 0 (infinite) on the platform; use the <code>idleTimeoutSeconds</code> input to control lifecycle.</li>
-            </ul>
-            </div>
         </section>
     </main>
 
@@ -254,17 +219,33 @@
             });
         }
 
-        function toggleCollapse(id) {
-            const content = document.getElementById(id);
-            const button = document.getElementById(id + 'Btn');
+        // Client-clock timestamp (ms) when idle shutdown will fire, re-synced
+        // from /health. null means no active idle timeout (disabled/offline).
+        let shutdownDeadline = null;
 
-            if (content.classList.contains('collapsed')) {
-                content.classList.remove('collapsed');
-                button.textContent = 'Hide';
-            } else {
-                content.classList.add('collapsed');
-                button.textContent = 'Show';
+        function formatDuration(totalSecs) {
+            const s = Math.max(0, totalSecs);
+            const pad = (n) => String(n).padStart(2, '0');
+            const h = Math.floor(s / 3600);
+            const m = Math.floor((s % 3600) / 60);
+            const sec = s % 60;
+            return h > 0 ? `${h}:${pad(m)}:${pad(sec)}` : `${m}:${pad(sec)}`;
+        }
+
+        function renderCountdown() {
+            const badge = document.getElementById('shutdownBadge');
+            const text = document.getElementById('shutdownText');
+
+            if (shutdownDeadline === null) {
+                badge.style.display = 'none';
+                return;
             }
+
+            const remainingSecs = Math.round((shutdownDeadline - Date.now()) / 1000);
+            badge.style.display = '';
+            text.textContent = remainingSecs <= 0
+                ? 'Shutting down…'
+                : `Idle shutdown in ${formatDuration(remainingSecs)}`;
         }
 
         async function checkHealth() {
@@ -282,10 +263,18 @@
                     badge.className = 'status-badge unhealthy';
                     text.textContent = data.status || 'Unhealthy';
                 }
+
+                // remainingSecs is only present while an idle timeout is active.
+                shutdownDeadline = typeof data.remainingSecs === 'number'
+                    ? Date.now() + data.remainingSecs * 1000
+                    : null;
             } catch (error) {
                 badge.className = 'status-badge unhealthy';
                 text.textContent = 'Offline';
+                shutdownDeadline = null;
             }
+
+            renderCountdown();
         }
 
         // Check health on page load
@@ -293,6 +282,9 @@
 
         // Refresh health status every 30 seconds
         setInterval(checkHealth, 30000);
+
+        // Tick the idle-shutdown countdown locally between health syncs
+        setInterval(renderCountdown, 1000);
 
         // Proxy Mappings Management
         async function loadProxyMappings() {

--- a/sandbox/src/templates/landing.ts
+++ b/sandbox/src/templates/landing.ts
@@ -9,6 +9,20 @@ import { parse as parseHtml } from 'node-html-parser';
 interface LandingPageOptions {
     serverUrl: string;
     isLocalMode: boolean;
+    idleTimeoutSecs: number;
+}
+
+/** Human-readable duration for the idle-timeout sentence, e.g. "15 minutes". */
+function humanizeDuration(secs: number): string {
+    if (secs % 3600 === 0) {
+        const hours = secs / 3600;
+        return `${hours} hour${hours === 1 ? '' : 's'}`;
+    }
+    if (secs >= 60) {
+        const mins = Math.round(secs / 60);
+        return `${mins} minute${mins === 1 ? '' : 's'}`;
+    }
+    return `${secs} second${secs === 1 ? '' : 's'}`;
 }
 
 const templatePath = join(dirname(fileURLToPath(import.meta.url)), 'landing.ejs');
@@ -17,7 +31,7 @@ const landingTemplate = readFileSync(templatePath, 'utf8');
 const stylesPath = join(dirname(fileURLToPath(import.meta.url)), 'landing.css');
 const landingStyles = readFileSync(stylesPath, 'utf8');
 
-const STRIP_SELECTOR = 'script, style, [data-no-md], .copy-btn, .collapse-btn, .status-badge';
+const STRIP_SELECTOR = 'script, style, [data-no-md], .copy-btn, .status-badge';
 
 const nhm = new NodeHtmlMarkdown(
     {
@@ -39,19 +53,27 @@ const nhm = new NodeHtmlMarkdown(
     },
 );
 
-export function getLandingPageHTML({ serverUrl, isLocalMode }: LandingPageOptions): string {
+export function getLandingPageHTML({ serverUrl, isLocalMode, idleTimeoutSecs }: LandingPageOptions): string {
     const modeLabel = isLocalMode ? 'Local mode (deps skipped)' : 'Production mode';
 
     return ejs.render(landingTemplate, {
         serverUrl,
         modeLabel,
         isLocalMode,
+        idleTimeoutSecs,
+        idleTimeoutLabel: humanizeDuration(idleTimeoutSecs),
         styles: landingStyles,
     });
 }
 
-export function getLLMsMarkdown({ serverUrl }: { serverUrl: string }): string {
-    const html = getLandingPageHTML({ serverUrl, isLocalMode: false });
+export function getLLMsMarkdown({
+    serverUrl,
+    idleTimeoutSecs,
+}: {
+    serverUrl: string;
+    idleTimeoutSecs: number;
+}): string {
+    const html = getLandingPageHTML({ serverUrl, isLocalMode: false, idleTimeoutSecs });
     const root = parseHtml(html);
     root.querySelectorAll(STRIP_SELECTOR).forEach((el) => el.remove());
     return `${nhm.translate(root.toString()).trim()}\n`;


### PR DESCRIPTION
- Remove the per-section collapse buttons and the Configuration card; everything's now always visible, with the idle timeout shown in the hero from the real 15-min constant (was a stale "10m").
- Rename the MCP block to "Set up examples" (Claude Code, Codex, mcpc) and note no auth is needed beyond the URL.
- Add a live idle-shutdown countdown badge, fed by new `/health` fields.

https://claude.ai/code/session_01VrAG9vvgLRidBynEFVbnQC