### PR TITLE
Rename skills input to agentSkills; add Seconds unit to idle timeout

### DIFF
--- a/claude-code/.actor/actor.json
+++ b/claude-code/.actor/actor.json
@@ -15,7 +15,7 @@
     "type": "object",
     "schemaVersion": 1,
     "properties": {
-       "skills": {
+       "agentSkills": {
         "title": "Skills",
         "type": "string",
         "description": "Skill packages to install for the AI coding agent — SKILLS.md files with specialized instructions (see https://skills.sh/). One skill per line, e.g. `anthropics/skills` (blank lines and `#` comments are ignored), or a JSON array like `[\"apify/agent-skills\", \"anthropics/skills\"]`.",

--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -25,7 +25,7 @@ This Actor [metamorphs](https://docs.apify.com/platform/actors/development/progr
 
 | Input | Description | Default |
 |-------|-------------|---------|
-| `skills` | Skill packages to install (SKILLS.md files), one per line or JSON array | `apify/agent-skills` |
+| `agentSkills` | Skill packages to install (SKILLS.md files), one per line or JSON array | `apify/agent-skills` |
 | `initShellScript` | Bash script to run before Claude Code starts | - |
 | `idleTimeoutSeconds` | Shutdown after inactivity | 900 |
 

--- a/openclaw/.actor/actor.json
+++ b/openclaw/.actor/actor.json
@@ -15,7 +15,7 @@
     "type": "object",
     "schemaVersion": 1,
     "properties": {
-       "skills": {
+       "agentSkills": {
         "title": "Skills",
         "type": "string",
         "description": "Skill packages to install for the AI coding agent — SKILLS.md files with specialized instructions (see https://skills.sh/). One skill per line, e.g. `anthropics/skills` (blank lines and `#` comments are ignored), or a JSON array like `[\"apify/agent-skills\", \"anthropics/skills\"]`.",

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -27,7 +27,7 @@ On startup, it:
 
 | Input | Description | Default |
 |-------|-------------|---------|
-| `skills` | Skill packages to install (SKILLS.md files), one per line or JSON array | `apify/agent-skills` |
+| `agentSkills` | Skill packages to install (SKILLS.md files), one per line or JSON array | `apify/agent-skills` |
 | `initShellScript` | Bash script to run before OpenClaw starts | - |
 | `idleTimeoutSeconds` | Shutdown after inactivity (0 = disabled) | 0 |
 

--- a/opencode/.actor/actor.json
+++ b/opencode/.actor/actor.json
@@ -15,7 +15,7 @@
     "type": "object",
     "schemaVersion": 1,
     "properties": {
-       "skills": {
+       "agentSkills": {
         "title": "Skills",
         "type": "string",
         "description": "Skill packages to install for the AI coding agent — SKILLS.md files with specialized instructions (see https://skills.sh/). One skill per line, e.g. `anthropics/skills` (blank lines and `#` comments are ignored), or a JSON array like `[\"apify/agent-skills\", \"anthropics/skills\"]`.",

--- a/opencode/README.md
+++ b/opencode/README.md
@@ -24,7 +24,7 @@ This Actor [metamorphs](https://docs.apify.com/platform/actors/development/progr
 
 | Input | Description | Default |
 |-------|-------------|---------|
-| `skills` | Skill packages to install (SKILLS.md files), one per line or JSON array | `apify/agent-skills` |
+| `agentSkills` | Skill packages to install (SKILLS.md files), one per line or JSON array | `apify/agent-skills` |
 | `initShellScript` | Bash script to run before OpenCode starts | - |
 | `idleTimeoutSeconds` | Shutdown after inactivity | 900 |
 

--- a/sandbox/.actor/actor.json
+++ b/sandbox/.actor/actor.json
@@ -16,7 +16,7 @@
         "type": "object",
         "schemaVersion": 1,
         "properties": {
-            "skills": {
+            "agentSkills": {
                 "title": "Skills",
                 "type": "string",
                 "description": "Skill packages to install for the AI coding agent — SKILLS.md files with specialized instructions (see https://skills.sh/). One skill per line — a GitHub `owner/repo` (e.g. `anthropics/skills`) or repo URL (e.g. `https://github.com/anthropics/skills`); blank lines and `#` comments are ignored. Also accepts a JSON array like `[\"apify/agent-skills\", \"anthropics/skills\"]`.",
@@ -53,11 +53,12 @@
                 "isSecret": true
             },
             "idleTimeoutSecs": {
-                "title": "Idle timeout seconds",
+                "title": "Idle timeout",
                 "type": "integer",
                 "description": "The container shuts down automatically after this many seconds of inactivity (no requests or shell interaction). Set to 0 to disable. Recommended: set the Actor timeout to 0 (infinite) when using this.",
                 "default": 900,
                 "editor": "number",
+                "unit": "Seconds",
                 "prefill": 900
             },
             "proxyMappings": {

--- a/sandbox/src/main.ts
+++ b/sandbox/src/main.ts
@@ -81,7 +81,7 @@ const userEnvVars = parseEnvVars(input?.envVars);
 setUserEnvVars(userEnvVars);
 
 const nodeDependencies = parseNodeDependencies(input?.nodeDependencies);
-const skills = parseSkills(input?.skills);
+const skills = parseSkills(input?.agentSkills);
 
 log.info('Actor input retrieved', {
     mode: isLocalMode ? 'local' : 'production',

--- a/sandbox/src/templates/landing.css
+++ b/sandbox/src/templates/landing.css
@@ -366,6 +366,10 @@ code {
     border: 1px solid var(--border);
     white-space: nowrap;
 }
+a.status-badge:hover {
+    text-decoration: none;
+    border-color: var(--text-faint);
+}
 .status-dot {
     width: 8px;
     height: 8px;

--- a/sandbox/src/templates/landing.ejs
+++ b/sandbox/src/templates/landing.ejs
@@ -15,10 +15,10 @@
                 <p class="lead">Containerized sandbox environment for AI coding operations. Connect through HTTP, MCP, or the interactive shell.</p>
             </div>
             <div data-no-md style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap;">
-                <div class="status-badge loading" id="statusBadge">
+                <a class="status-badge loading" id="statusBadge" href="/health" target="_blank" rel="noopener noreferrer">
                     <span class="status-dot"></span>
                     <span id="statusText">Checking...</span>
-                </div>
+                </a>
                 <% if (isLocalMode) { %>
                     <div class="badge"><%= modeLabel %></div>
                 <% } %>
@@ -41,7 +41,6 @@
                 <li><strong>Landing page</strong>: <a href="<%= serverUrl %>/"><%= serverUrl %>/</a></li>
                 <li><strong>Shell terminal</strong>: <a href="<%= serverUrl %>/shell/"><%= serverUrl %>/shell/</a></li>
                 <li><strong>File browser</strong>: <a href="<%= serverUrl %>/browse"><%= serverUrl %>/browse</a></li>
-                <li><strong>Health check</strong>: <a href="<%= serverUrl %>/health"><%= serverUrl %>/health</a></li>
                 <li><strong>MCP endpoint</strong>: <a href="<%= serverUrl %>/mcp"><%= serverUrl %>/mcp</a></li>
             </ul>
         </section>

--- a/sandbox/src/types.ts
+++ b/sandbox/src/types.ts
@@ -19,7 +19,7 @@ export interface ActorInput {
      * or repo URL (e.g. `https://github.com/anthropics/skills`); blank lines and
      * `#` comments ignored — or a JSON array of skill name strings.
      */
-    skills?: string;
+    agentSkills?: string;
 
     /**
      * Node.js dependencies for JavaScript and TypeScript code execution.


### PR DESCRIPTION
- Rename the `skills` input field to `agentSkills` across all four Actor schemas, the sandbox type/read, and READMEs.
- `idleTimeoutSecs`: drop "seconds" from the caption and show it as a `unit` ("Seconds") instead.

https://claude.ai/code/session_01Q4iMZ539aG4o1pqc5V6bDz