### PR TITLE
Rename initShellScript to initBashScript across all actors

### DIFF
--- a/claude-code/.actor/actor.json
+++ b/claude-code/.actor/actor.json
@@ -23,7 +23,7 @@
         "default": "apify/agent-skills",
         "prefill": "apify/agent-skills\n# One skill per line, e.g. anthropics/skills"
       },
-      "initShellScript": {
+      "initBashScript": {
         "title": "Initialization script",
         "type": "string",
         "description": "Optional bash script to run on startup for installing packages or setting up the environment.",

--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -26,7 +26,7 @@ This Actor [metamorphs](https://docs.apify.com/platform/actors/development/progr
 | Input | Description | Default |
 |-------|-------------|---------|
 | `agentSkills` | Skill packages to install (SKILLS.md files), one per line or JSON array | `apify/agent-skills` |
-| `initShellScript` | Bash script to run before Claude Code starts | - |
+| `initBashScript` | Bash script to run before Claude Code starts | - |
 | `idleTimeoutSeconds` | Shutdown after inactivity | 900 |
 
 ## 📚 Skills Support

--- a/openclaw/.actor/actor.json
+++ b/openclaw/.actor/actor.json
@@ -23,7 +23,7 @@
         "default": "apify/agent-skills",
         "prefill": "apify/agent-skills\n# One skill per line, e.g. anthropics/skills"
       },
-      "initShellScript": {
+      "initBashScript": {
         "title": "Initialization script",
         "type": "string",
         "description": "Optional bash script to run on startup for installing packages or setting up the environment.",

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -28,7 +28,7 @@ On startup, it:
 | Input | Description | Default |
 |-------|-------------|---------|
 | `agentSkills` | Skill packages to install (SKILLS.md files), one per line or JSON array | `apify/agent-skills` |
-| `initShellScript` | Bash script to run before OpenClaw starts | - |
+| `initBashScript` | Bash script to run before OpenClaw starts | - |
 | `idleTimeoutSeconds` | Shutdown after inactivity (0 = disabled) | 0 |
 
 ## 📚 Skills Support

--- a/openclaw/src/main.ts
+++ b/openclaw/src/main.ts
@@ -95,7 +95,7 @@ sleep 3
 echo "OpenClaw started: http://127.0.0.1:18789/openclaw/"`;
 
 // Combine OpenClaw init script with any user-provided init script
-const userInitScript = (input as Record<string, unknown>)?.initShellScript as string | undefined;
+const userInitScript = (input as Record<string, unknown>)?.initBashScript as string | undefined;
 const combinedInitScript = userInitScript
   ? `${openclawInitScript}\n\n# User-provided init script\n${userInitScript}`
   : openclawInitScript;
@@ -103,7 +103,7 @@ const combinedInitScript = userInitScript
 // Build the merged input, injecting the OpenClaw init script
 const mergedInput = {
   ...((input as Record<string, unknown>) || {}),
-  initShellScript: combinedInitScript,
+  initBashScript: combinedInitScript,
 };
 
 console.log(`🔄 Metamorphing into: ${sandboxActorName}`);

--- a/opencode/.actor/actor.json
+++ b/opencode/.actor/actor.json
@@ -23,7 +23,7 @@
         "default": "apify/agent-skills",
         "prefill": "apify/agent-skills\n# One skill per line, e.g. anthropics/skills"
       },
-      "initShellScript": {
+      "initBashScript": {
         "title": "Initialization script",
         "type": "string",
         "description": "Optional bash script to run on startup for installing packages or setting up the environment.",

--- a/opencode/README.md
+++ b/opencode/README.md
@@ -25,7 +25,7 @@ This Actor [metamorphs](https://docs.apify.com/platform/actors/development/progr
 | Input | Description | Default |
 |-------|-------------|---------|
 | `agentSkills` | Skill packages to install (SKILLS.md files), one per line or JSON array | `apify/agent-skills` |
-| `initShellScript` | Bash script to run before OpenCode starts | - |
+| `initBashScript` | Bash script to run before OpenCode starts | - |
 | `idleTimeoutSeconds` | Shutdown after inactivity | 900 |
 
 ## 📚 Skills Support

--- a/sandbox/.actor/actor.json
+++ b/sandbox/.actor/actor.json
@@ -38,7 +38,7 @@
                 "editor": "textarea",
                 "prefill": "# One package per line (requirements.txt format):\n# requests==2.31.0\n# pandas"
             },
-            "initShellScript": {
+            "initBashScript": {
                 "title": "Initialization script",
                 "type": "string",
                 "description": "Optional bash script run on startup, after dependencies are installed. Use it to install system packages, create directories, or set up the environment.",

--- a/sandbox/src/main.ts
+++ b/sandbox/src/main.ts
@@ -91,7 +91,7 @@ log.info('Actor input retrieved', {
     hasSkills: skills.length > 0,
     hasNodeDependencies: Object.keys(nodeDependencies).length > 0,
     hasPythonRequirements: !!input?.pythonRequirements?.trim().length,
-    hasInitScript: !!input?.initShellScript?.trim().length,
+    hasInitScript: !!input?.initBashScript?.trim().length,
     envVarKeys: Object.keys(userEnvVars),
     mcpConnectorCount: input?.mcpConnectors?.length ?? 0,
 });
@@ -150,9 +150,9 @@ if (!setupResult.success) {
 }
 
 // Execute init script if provided and not empty
-if (input?.initShellScript && input.initShellScript.trim().length > 0) {
+if (input?.initBashScript && input.initBashScript.trim().length > 0) {
     log.info('Executing init script...');
-    const initResult = await executeInitScript(input.initShellScript);
+    const initResult = await executeInitScript(input.initBashScript);
     if (initResult.exitCode !== 0) {
         // The output and failure summary were already streamed by executeInitScript;
         // record the reason so the /health endpoint can report it.

--- a/sandbox/src/types.ts
+++ b/sandbox/src/types.ts
@@ -39,7 +39,7 @@ export interface ActorInput {
      * Optional bash script to customize the sandbox environment
      * Runs after dependency installation in /sandbox directory
      */
-    initShellScript?: string;
+    initBashScript?: string;
 
     /**
      * Secret environment variables exposed to the sandbox shell, init script,

--- a/sandbox/tests/e2e.ts
+++ b/sandbox/tests/e2e.ts
@@ -936,7 +936,7 @@ async function main(): Promise<void> {
             nodeDependencies: 'zod@^3.22.0',
             pythonRequirements: 'numpy>=1.24.0',
             envVars: 'TEST_E2E_SECRET=hunter2-do-not-leak',
-            initShellScript: [
+            initBashScript: [
                 '#!/bin/bash',
                 'mkdir -p /sandbox/test-e2e-init',
                 "echo 'E2E test init script executed' > /sandbox/test-e2e-init/status.txt",


### PR DESCRIPTION
- Renames the `initShellScript` input to `initBashScript` so the name matches the behavior: the script is always executed under bash (`spawn('bash', ...)`), never `sh` or the login shell.
- Applied across the sandbox Actor and the openclaw/opencode/claude-code wrappers — input schemas, types, READMEs, and the e2e test. The openclaw `metamorph` payload that feeds sandbox is renamed in lockstep so the value still reaches it.
- Breaking change for the public input schema: existing tasks/API calls passing `initShellScript` will have it silently ignored. No backward-compat fallback is included.

https://claude.ai/code/session_019yGCKrihi3Ax1uUDonYk4i