### PR TITLE
Improve landing page badge layout and typography

### DIFF
--- a/sandbox/src/templates/landing.css
+++ b/sandbox/src/templates/landing.css
@@ -66,6 +66,7 @@ body {
     color: var(--text);
     padding: 40px 24px 64px;
     min-height: 100vh;
+    font-size: 14px;
     line-height: 1.6;
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
@@ -239,9 +240,9 @@ code {
     color: var(--text-muted);
 }
 .example-label {
-    font-size: 12.5px;
-    font-weight: 600;
-    color: var(--text-muted);
+    font-size: 15px;
+    font-weight: 650;
+    color: var(--text-strong);
     margin-top: 4px;
     line-height: 1.4;
 }
@@ -348,6 +349,11 @@ a.status-badge:hover {
 .status-icon {
     font-size: 12px;
     line-height: 1;
+}
+/* Keep countdown digits fixed-width so the badge doesn't jiggle as it ticks */
+.countdown {
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: 'tnum';
 }
 .status-badge.healthy .status-dot {
     background: var(--ok);

--- a/sandbox/src/templates/landing.ejs
+++ b/sandbox/src/templates/landing.ejs
@@ -14,14 +14,14 @@
                 <h1>Apify AI Code Sandbox</h1>
                 <p class="lead">Containerized sandbox for AI coding operations. Connect through REST API, MCP, or the interactive shell.<% if (idleTimeoutSecs > 0) { %> The container shuts down automatically after <%= idleTimeoutLabel %> of inactivity.<% } %></p>
             </div>
-            <div data-no-md style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap;">
+            <div data-no-md style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; flex-shrink: 0;">
                 <a class="status-badge loading" id="statusBadge" href="/health" target="_blank" rel="noopener noreferrer">
                     <span class="status-dot"></span>
                     <span id="statusText">Checking...</span>
                 </a>
                 <div class="status-badge" id="shutdownBadge" style="display: none;" title="Time remaining before automatic idle shutdown">
                     <span class="status-icon">⏻</span>
-                    <span id="shutdownText"></span>
+                    <span id="shutdownText" class="countdown"></span>
                 </div>
                 <% if (isLocalMode) { %>
                     <div class="badge"><%= modeLabel %></div>


### PR DESCRIPTION
- Keep the Healthy and idle-shutdown badges on one line instead of stacking them.
- Render the idle-shutdown counter with fixed-width digits so the badge stops jiggling as it ticks.
- Fix the type hierarchy so section labels (e.g. "Working directories") read as headings rather than looking smaller than the body text beneath them.

https://claude.ai/code/session_01GHCCa8SXd7fSDnyEvfr1eU