### PR TITLE
Lazy-install AI coding agents to reduce image size

### DIFF
--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -211,7 +211,7 @@ RUN mkdir -p /root/.codex && \
         'sandbox_mode = "danger-full-access"' \
         '' \
         '[model_providers.apify-openrouter]' \
-        'name = "Apify OpenRouter Proxy"' \
+        'name = "apify/openrouter Actor"' \
         'base_url = "https://openrouter.apify.actor/api/v1"' \
         'env_key = "APIFY_TOKEN"' \
         'requires_openai_auth = false' \

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -203,9 +203,12 @@ RUN mkdir -p /root/.claude && \
 # wire_api MUST be "responses": Codex removed support for the older "chat"
 # (chat/completions) wire protocol, and the Apify OpenRouter proxy speaks the
 # OpenAI Responses API, so Codex talks to it at <base_url>/responses.
+# model uses OpenRouter's "~<vendor>/<family>-latest" alias so it auto-tracks the
+# newest release (e.g. the current Claude Sonnet) instead of pinning a version
+# that goes stale.
 RUN mkdir -p /root/.codex && \
     printf '%s\n' \
-        'model = "anthropic/claude-sonnet-4.5"' \
+        'model = "~anthropic/claude-sonnet-latest"' \
         'model_provider = "apify-openrouter"' \
         'approval_policy = "never"' \
         'sandbox_mode = "danger-full-access"' \

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -97,24 +97,13 @@ RUN npm install -g tsx \
     && npm install -g @apify/mcpc \
     && npm cache clean --force
 
-# Install AI coding agent CLIs via npm. All three ship platform-specific
-# native binaries through optional deps; --include=optional ensures the
-# Linux binary is fetched. Codex and OpenCode bundle their own runtimes
-# (Rust / Bun) inside the binary; Claude Code ships a Bun-compiled binary
-# that does not invoke Node at runtime.
-#
-# OpenCode publishes two interchangeable x64 builds: an AVX2 build
-# (opencode-linux-x64) and a non-AVX2 "baseline" build. Neither carries a
-# cpu/libc field npm can filter on, so npm installs BOTH (~149 MB each) and
-# OpenCode selects one at runtime via an AVX2 probe. Every x86-64 server CPU
-# since ~2013 has AVX2, so we delete the baseline build to reclaim ~149 MB.
-# This must happen in the same layer as the install to actually shrink the image.
-RUN npm install -g --include=optional \
-        @anthropic-ai/claude-code \
-        @openai/codex \
-        opencode-ai \
-    && rm -rf "$(npm root -g)/opencode-linux-x64-baseline" \
-    && npm cache clean --force
+# NOTE: The AI coding agent CLIs (Claude Code, OpenCode, Codex) are deliberately
+# NOT installed here. They are installed lazily on first use — when the user
+# clicks a launch button on the landing page or types `claude`/`opencode`/`codex`
+# in the shell — by the functions in agent-launchers.sh (copied in below and
+# sourced from the shell rcfile). This keeps the image small and always pulls
+# the latest agent release. Their configuration overrides are still baked in
+# below, so each agent starts pre-configured the moment it is installed.
 
 # Create sandbox directory for operations
 RUN mkdir -p /sandbox && chmod 755 /sandbox
@@ -225,6 +214,18 @@ RUN mkdir -p /root/.codex && \
         'requires_openai_auth = false' \
         'wire_api = "chat"' \
         > /root/.codex/config.toml
+
+# Lazy-install launchers for the coding agents. Sourced by the shell rcfile (see
+# SANDBOX_BASHRC in src/templates/shell.ts) so a launch button or a plain
+# `claude`/`opencode`/`codex` installs the agent on first use, then runs it.
+# Validate the script at build time — both that it parses and that it actually
+# defines the three functions — so a broken launcher fails the build instead of
+# the user's first launch.
+COPY scripts/agent-launchers.sh /app/agent-launchers.sh
+RUN bash -n /app/agent-launchers.sh \
+    && bash -c '. /app/agent-launchers.sh; for f in claude opencode codex; do \
+        [ "$(type -t "$f")" = function ] || { echo "agent-launchers.sh did not define function: $f"; exit 1; }; \
+    done'
 
 # Capture tool versions at build time for fast shell startup
 COPY scripts/capture-versions.sh /tmp/capture-versions.sh

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -200,6 +200,9 @@ RUN mkdir -p /root/.claude && \
 # default to requires_openai_auth=false, so Codex starts straight into a session with
 # no "Sign in with ChatGPT" prompt. Bare keys must precede the [table] headers so the
 # MCP-connector block appended at runtime (see src/mcp-agent-config.ts) stays valid TOML.
+# wire_api MUST be "responses": Codex removed support for the older "chat"
+# (chat/completions) wire protocol, and the Apify OpenRouter proxy speaks the
+# OpenAI Responses API, so Codex talks to it at <base_url>/responses.
 RUN mkdir -p /root/.codex && \
     printf '%s\n' \
         'model = "anthropic/claude-sonnet-4.5"' \
@@ -212,7 +215,7 @@ RUN mkdir -p /root/.codex && \
         'base_url = "https://openrouter.apify.actor/api/v1"' \
         'env_key = "APIFY_TOKEN"' \
         'requires_openai_auth = false' \
-        'wire_api = "chat"' \
+        'wire_api = "responses"' \
         > /root/.codex/config.toml
 
 # Lazy-install launchers for the coding agents. Sourced by the shell rcfile (see

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -203,12 +203,14 @@ RUN mkdir -p /root/.claude && \
 # wire_api MUST be "responses": Codex removed support for the older "chat"
 # (chat/completions) wire protocol, and the Apify OpenRouter proxy speaks the
 # OpenAI Responses API, so Codex talks to it at <base_url>/responses.
-# model uses OpenRouter's "~<vendor>/<family>-latest" alias so it auto-tracks the
-# newest release (e.g. the current Claude Sonnet) instead of pinning a version
-# that goes stale.
+# model uses OpenRouter's "~openai/gpt-latest" alias — Codex's native OpenAI
+# flagship, auto-tracking the newest release instead of pinning a stale version.
+# [projects."/sandbox"] pre-trusts the sandbox working dir (ttyd starts shells
+# there) so Codex skips its interactive "Do you trust this directory?" prompt on
+# first launch; Codex has no global trust-all switch.
 RUN mkdir -p /root/.codex && \
     printf '%s\n' \
-        'model = "~anthropic/claude-sonnet-latest"' \
+        'model = "~openai/gpt-latest"' \
         'model_provider = "apify-openrouter"' \
         'approval_policy = "never"' \
         'sandbox_mode = "danger-full-access"' \
@@ -219,6 +221,9 @@ RUN mkdir -p /root/.codex && \
         'env_key = "APIFY_TOKEN"' \
         'requires_openai_auth = false' \
         'wire_api = "responses"' \
+        '' \
+        '[projects."/sandbox"]' \
+        'trust_level = "trusted"' \
         > /root/.codex/config.toml
 
 # Lazy-install launchers for the coding agents. Sourced by the shell rcfile (see

--- a/sandbox/artifacts/opencode.json
+++ b/sandbox/artifacts/opencode.json
@@ -13,14 +13,14 @@
                 }
             },
             "models": {
-                "anthropic/claude-haiku-4.5": {
-                    "name": "Claude 4.5 Haiku"
+                "~anthropic/claude-haiku-latest": {
+                    "name": "Claude Haiku (latest)"
                 },
-                "anthropic/claude-sonnet-4.5": {
-                    "name": "Claude 4.5 Sonnet"
+                "~anthropic/claude-sonnet-latest": {
+                    "name": "Claude Sonnet (latest)"
                 },
-                "anthropic/claude-opus-4.5": {
-                    "name": "Claude 4.5 Opus"
+                "~anthropic/claude-opus-latest": {
+                    "name": "Claude Opus (latest)"
                 },
                 "x-ai/grok-code-fast-1": {
                     "name": "Grok Code Fast 1"
@@ -34,5 +34,5 @@
             }
         }
     },
-    "model": "apify-openrouter/anthropic/claude-sonnet-4.5"
+    "model": "apify-openrouter/~anthropic/claude-sonnet-latest"
 }

--- a/sandbox/artifacts/opencode.json
+++ b/sandbox/artifacts/opencode.json
@@ -34,5 +34,5 @@
             }
         }
     },
-    "model": "apify-openrouter/~anthropic/claude-sonnet-latest"
+    "model": "apify-openrouter/~anthropic/claude-opus-latest"
 }

--- a/sandbox/artifacts/opencode.json
+++ b/sandbox/artifacts/opencode.json
@@ -4,7 +4,7 @@
     "provider": {
         "apify-openrouter": {
             "npm": "@ai-sdk/openai-compatible",
-            "name": "Apify OpenRouter Proxy",
+            "name": "apify/openrouter Actor",
             "options": {
                 "baseURL": "https://openrouter.apify.actor/api/v1",
                 "apiKey": "dummy-api-key",

--- a/sandbox/scripts/agent-launchers.sh
+++ b/sandbox/scripts/agent-launchers.sh
@@ -1,0 +1,85 @@
+# shellcheck shell=bash
+#
+# Lazy installers for the bundled AI coding agents (Claude Code, OpenCode, Codex).
+#
+# The sandbox image ships each agent's *configuration* (provider/proxy settings,
+# auto-approve flags, MCP connectors — see the Dockerfile and mcp-agent-config.ts)
+# but no longer bundles the CLIs themselves. Each agent is instead installed on
+# first use with its official installer, then exec'd.
+#
+# They are defined as shell functions (rather than wrapper scripts on PATH) so
+# both entry points take the identical install-then-run path:
+#   - the landing-page launch buttons -> /shell?launch=claude (etc.), and
+#   - a plain `claude` / `opencode` / `codex` typed at the prompt.
+#
+# This file defines functions only and has no top-level side effects, so the
+# shell rcfile (SANDBOX_BASHRC) can source it cheaply on every shell start.
+
+# Ensure $1 (a binary name) is runnable, installing it via the command in $3 if
+# it is missing. $2 is a human-readable label for messages. Returns non-zero —
+# without running anything else — if the agent cannot be made available, so the
+# caller can bail out instead of printing a confusing "command not found".
+__sandbox_ensure_agent() {
+    local bin=$1 label=$2 installer=$3
+
+    # Already installed (from a previous launch, persisted across migrations)?
+    # `type -P` ignores this very function and looks only at PATH executables.
+    if type -P "$bin" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if [ -t 2 ]; then
+        printf '\033[0;34mInstalling %s (one-time setup on first launch)...\033[0m\n' "$label" >&2
+    else
+        printf 'Installing %s (one-time setup on first launch)...\n' "$label" >&2
+    fi
+
+    # `set -o pipefail` so a failed download (curl) fails the install instead of
+    # piping an empty script to the interpreter, which would exit 0 and look
+    # like success.
+    if ! bash -c "set -o pipefail; $installer"; then
+        printf 'Failed to install %s. Check the network connection and try again.\n' "$label" >&2
+        return 1
+    fi
+
+    # Drop bash's cached "not found" result, then re-check. The official
+    # installers place their binaries in directories already on PATH
+    # (~/.local/bin for Claude Code and Codex, ~/.opencode/bin for OpenCode);
+    # the loop is a fallback that prepends the install dir to PATH should an
+    # installer ever change its default location.
+    hash -r 2>/dev/null || true
+    if type -P "$bin" >/dev/null 2>&1; then
+        return 0
+    fi
+    local dir
+    for dir in "$HOME/.local/bin" "$HOME/.opencode/bin" "$HOME/.codex/bin" "$HOME/bin" /usr/local/bin; do
+        if [ -x "$dir/$bin" ]; then
+            export PATH="$dir:$PATH"
+            hash -r 2>/dev/null || true
+            return 0
+        fi
+    done
+
+    printf '%s was installed but "%s" was not found on PATH.\n' "$label" "$bin" >&2
+    return 1
+}
+
+# `command <bin>` bypasses these functions and runs the installed binary, so the
+# wrappers don't recurse into themselves.
+claude() {
+    __sandbox_ensure_agent claude 'Claude Code' \
+        'curl -fsSL https://claude.ai/install.sh | bash' || return
+    command claude "$@"
+}
+
+opencode() {
+    __sandbox_ensure_agent opencode 'OpenCode' \
+        'curl -fsSL https://opencode.ai/install | OPENCODE_INSTALL_DIR=$HOME/.opencode/bin bash' || return
+    command opencode "$@"
+}
+
+codex() {
+    __sandbox_ensure_agent codex 'Codex' \
+        'curl -fsSL https://chatgpt.com/codex/install.sh | CODEX_NON_INTERACTIVE=1 sh' || return
+    command codex "$@"
+}

--- a/sandbox/scripts/capture-versions.sh
+++ b/sandbox/scripts/capture-versions.sh
@@ -42,29 +42,12 @@ else
     echo "⚠️  MCP CLI: not installed"
 fi
 
-# Capture Claude CLI version (optional)
-if claude --version > "$VERSION_DIR/claude.txt" 2>/dev/null; then
-    echo "✅ Claude: $(cat "$VERSION_DIR/claude.txt")"
-else
-    echo "not installed" > "$VERSION_DIR/claude.txt"
-    echo "⚠️  Claude: not installed"
-fi
-
-# Capture OpenCode CLI version (optional)
-if opencode --version > "$VERSION_DIR/opencode.txt" 2>/dev/null; then
-    echo "✅ OpenCode: $(cat "$VERSION_DIR/opencode.txt")"
-else
-    echo "not installed" > "$VERSION_DIR/opencode.txt"
-    echo "⚠️  OpenCode: not installed"
-fi
-
-# Capture Codex CLI version (optional)
-if codex --version > "$VERSION_DIR/codex.txt" 2>/dev/null; then
-    echo "✅ Codex: $(cat "$VERSION_DIR/codex.txt")"
-else
-    echo "not installed" > "$VERSION_DIR/codex.txt"
-    echo "⚠️  Codex: not installed"
-fi
+# Claude Code, OpenCode, and Codex are NOT captured here: they are installed
+# lazily on first use (see agent-launchers.sh), so there is nothing to probe at
+# build time. The shell welcome message detects them at runtime instead — it
+# falls back to `<agent> --version` when the cached version file is absent — so
+# it shows the real version once an agent has been installed, and "not installed"
+# before that.
 
 echo ""
 echo "🎉 Version capture complete! Files stored in $VERSION_DIR"

--- a/sandbox/src/mcp-agent-config.ts
+++ b/sandbox/src/mcp-agent-config.ts
@@ -3,9 +3,10 @@
  *
  * Translates the user's MCP Connectors (the same list written to
  * /sandbox/mcp.json by mcp-connections.ts) into the native config format of
- * each pre-installed coding agent — Claude Code, Codex, and OpenCode — so the
- * connectors are available as tools the moment the agent starts, with no
- * `claude mcp add` / `mcpc connect` step.
+ * each supported coding agent — Claude Code, Codex, and OpenCode — so the
+ * connectors are available as tools the moment the agent starts (installed on
+ * first use; see agent-launchers.sh), with no `claude mcp add` / `mcpc connect`
+ * step.
  *
  * Why a translation step rather than pointing every agent at /sandbox/mcp.json:
  * the three agents disagree on both the config schema and the env-var syntax.

--- a/sandbox/src/templates/shell.ts
+++ b/sandbox/src/templates/shell.ts
@@ -99,10 +99,16 @@ alias ll='ls -alF'
 alias la='ls -A'
 alias l='ls -CF'
 
+# Claude Code, OpenCode, and Codex are installed on first use — the image ships
+# only their config, not the CLIs. agent-launchers.sh defines a function per
+# agent that installs it (if missing) then runs it, so the landing-page launch
+# buttons and a plain \`claude\`/\`opencode\`/\`codex\` share one install-then-run path.
+[ -f /app/agent-launchers.sh ] && . /app/agent-launchers.sh
+
 # AI coding agents auto-approve all confirmations — safe inside the sandbox.
 # Claude Code: bypass mode + prompt suppression are baked into the image via
-# settings.json (see the Dockerfile), so a plain \`claude\` starts cleanly on every
-# launch path. Codex and OpenCode auto-approve via their own config files.
+# settings.json (see the Dockerfile). Codex and OpenCode auto-approve via their
+# own config files.
 
 # Print welcome message (once per session; the launch wrapper sources this
 # rcfile twice — to set up the env, then again for the persistent shell).


### PR DESCRIPTION
- Stop bundling the Claude Code, OpenCode, and Codex CLIs in the image (~300 MB). Each now installs on first use via its official `curl | bash` installer, then runs — every config override and launch button is kept. A new `agent-launchers.sh`, sourced by the shell rcfile, routes both the landing-page buttons and a plain `claude`/`opencode`/`codex` through one install-then-run path.
- Default the agents to OpenRouter "latest" aliases so they never pin a stale model: Codex → `~openai/gpt-latest` (its native OpenAI flagship), OpenCode → `~anthropic/claude-opus-latest`. Claude Code is untouched — it already self-selects its own default through the proxy.
- Make the Codex config work with the current CLI: `wire_api = "responses"` (Codex dropped the legacy `chat` protocol; the proxy speaks the Responses API), and pre-trust `/sandbox` so Codex skips its first-run "trust this directory?" prompt.
- Rename the provider's display label to "apify/openrouter Actor" (the `apify-openrouter` id is unchanged).

https://claude.ai/code/session_01FRjAxs4M3ooLmcn2nezRkR