### PR TITLE
Pin Codex model to gpt-5.5 for proper metadata resolution

### DIFF
--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -203,14 +203,18 @@ RUN mkdir -p /root/.claude && \
 # wire_api MUST be "responses": Codex removed support for the older "chat"
 # (chat/completions) wire protocol, and the Apify OpenRouter proxy speaks the
 # OpenAI Responses API, so Codex talks to it at <base_url>/responses.
-# model uses OpenRouter's "~openai/gpt-latest" alias — Codex's native OpenAI
-# flagship, auto-tracking the newest release instead of pinning a stale version.
+# model is pinned to OpenRouter's "openai/gpt-5.5", OpenAI's current flagship.
+# Pinning the concrete version rather than the "~openai/gpt-latest" floating
+# alias lets Codex resolve its bundled model metadata (context window etc.) by
+# matching the "gpt-5.5" slug suffix, so it no longer warns that metadata is
+# "not found" and silently falls back to defaults that mis-size the context
+# window. Bump this when a newer flagship ships.
 # [projects."/sandbox"] pre-trusts the sandbox working dir (ttyd starts shells
 # there) so Codex skips its interactive "Do you trust this directory?" prompt on
 # first launch; Codex has no global trust-all switch.
 RUN mkdir -p /root/.codex && \
     printf '%s\n' \
-        'model = "~openai/gpt-latest"' \
+        'model = "openai/gpt-5.5"' \
         'model_provider = "apify-openrouter"' \
         'approval_policy = "never"' \
         'sandbox_mode = "danger-full-access"' \


### PR DESCRIPTION
Codex's baked config used OpenRouter's `~openai/gpt-latest` floating alias, which Codex's bundled model registry can't match — so on launch it warned "Model metadata not found" and fell back to defaults that mis-size the context window.

- Pin the Codex model from the `~openai/gpt-latest` floating alias to the concrete `openai/gpt-5.5` slug, which Codex resolves to its bundled metadata (272K context window) via slug-suffix matching — silencing the warning.
- It's a deliberate pin, not the floating alias, so bump it when a newer OpenAI flagship ships (noted in the config comment).

https://claude.ai/code/session_01H5NXwnYWBgJ3i26uVM2ube