### PR TITLE
Add status message reporting for Actor lifecycle stages

### DIFF
--- a/sandbox/src/environment.ts
+++ b/sandbox/src/environment.ts
@@ -13,6 +13,7 @@ import {
     PYTHON_CODE_DIR,
     SANDBOX_DIR,
 } from './consts.js';
+import { setStatusMessage } from './status.js';
 
 const execAsync = promisify(exec);
 
@@ -169,6 +170,7 @@ export const installNodeLibraries = async (
 
     const packageSpecs = Object.entries(dependencies).map(([pkg, version]) => `${pkg}@${version}`);
     log.info('Installing Node.js dependencies', { count: packageSpecs.length, packages: packageSpecs });
+    await setStatusMessage('Installing Node.js dependencies');
 
     const installed: string[] = [];
     const failed: { library: string; error: string }[] = [];
@@ -232,6 +234,7 @@ export const installPythonLibraries = async (
     }
 
     log.info('Installing Python requirements', { count: requirements.length, requirements });
+    await setStatusMessage('Installing Python dependencies');
 
     const installed: string[] = [];
     const failed: { library: string; error: string }[] = [];

--- a/sandbox/src/main.ts
+++ b/sandbox/src/main.ts
@@ -17,6 +17,7 @@ import { configureAgentMcpServers } from './mcp-agent-config.js';
 import { writeMcpConfig } from './mcp-connections.js';
 import { translateLaunchParam } from './shell-launch.js';
 import { parseNodeDependencies } from './node-deps.js';
+import { setStatusMessage } from './status.js';
 import {
     appendFile,
     createDirectory,
@@ -151,6 +152,7 @@ if (!setupResult.success) {
 // Execute init script if provided and not empty
 if (input?.initBashScript && input.initBashScript.trim().length > 0) {
     log.info('Executing init script...');
+    await setStatusMessage('Running setup script');
     const initResult = await executeInitScript(input.initBashScript);
     if (initResult.exitCode !== 0) {
         // The output and failure summary were already streamed by executeInitScript;
@@ -212,6 +214,7 @@ if (!isLocalMode) {
 initializationComplete = true;
 lastActivityAt = Date.now();
 log.info('Actor startup complete - ready for requests');
+await setStatusMessage('Sandbox is live');
 
 // Initialize bridges
 initializeBridges(input?.bridges);
@@ -1382,6 +1385,7 @@ server.listen(port, () => {
             if (idleTimeMs > idleTimeoutSecs * 1000) {
                 const message = `Sandbox shut down after ${Math.round(idleTimeoutSecs)} seconds of inactivity.`;
                 log.warning(message);
+                await setStatusMessage('Sandbox is shutting down');
                 await Actor.exit({ statusMessage: message });
             }
         }, 30000); // Check every 30 seconds

--- a/sandbox/src/status.ts
+++ b/sandbox/src/status.ts
@@ -1,0 +1,22 @@
+// Run status message reporting for the Apify Console.
+import { Actor, log } from 'apify';
+
+const isLocalMode = process.env.MODE === 'local';
+
+/**
+ * Update the Actor run's status message shown in the Apify Console so each
+ * lifecycle stage is visible at a glance (installing dependencies, running the
+ * setup script, live, shutting down).
+ *
+ * Best-effort by design: a failed status update — or running locally with no
+ * platform run to report to — must never interrupt startup or shutdown, so the
+ * call is swallowed and only logged.
+ */
+export const setStatusMessage = async (message: string): Promise<void> => {
+    if (isLocalMode) return;
+    try {
+        await Actor.setStatusMessage(message);
+    } catch (err) {
+        log.warning('Failed to set Actor status message', { message, error: (err as Error).message });
+    }
+};


### PR DESCRIPTION
- Surface each sandbox lifecycle stage as an Actor status message in the Apify Console, so a run's progress is visible at a glance: installing Node.js/Python dependencies, running the setup script, sandbox live, and shutting down.
- The new `setStatusMessage` helper is best-effort — a no-op in local mode and it swallows/logs any failure — so a status update can never interrupt startup or shutdown.
- Node and Python deps install in parallel, so when both are provided the two "Installing…" messages briefly race; kept parallel rather than serializing for a cosmetic message.

https://claude.ai/code/session_01KAhHPo8KQLi8ujAujwCqxB