### PR TITLE
Widen homepage intro and drop redundant health-status line

### DIFF
--- a/sandbox/src/templates/landing.css
+++ b/sandbox/src/templates/landing.css
@@ -88,9 +88,8 @@ a:hover {
 
 .hero {
     display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 20px;
+    flex-direction: column;
+    gap: 14px;
     padding: 30px;
     background: var(--hero-bg);
     border: 1px solid var(--border);
@@ -105,16 +104,28 @@ a:hover {
     height: 3px;
     background: var(--accent-bar);
 }
+.hero-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 20px;
+    flex-wrap: wrap;
+}
+.hero-badges {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+    flex-shrink: 0;
+}
 h1 {
     font-size: 30px;
     font-weight: 700;
     letter-spacing: -0.02em;
     color: var(--text-strong);
-    margin-bottom: 8px;
 }
 .lead {
     color: var(--text-muted);
-    max-width: 64ch;
     font-size: 15px;
 }
 .badge {
@@ -466,7 +477,7 @@ a.status-badge:hover {
     body {
         padding: 22px 14px 40px;
     }
-    .hero {
+    .hero-bar {
         flex-direction: column;
         align-items: flex-start;
     }

--- a/sandbox/src/templates/landing.ejs
+++ b/sandbox/src/templates/landing.ejs
@@ -10,28 +10,27 @@
 <body>
     <main class="page">
         <header class="hero">
-            <div>
+            <div class="hero-bar">
                 <h1>Apify AI Code Sandbox</h1>
-                <p class="lead">An Actor for secure execution of arbitrary code. Connect using MCP, REST API, or interactive shell.<% if (idleTimeoutSecs > 0) { %> The Actor shuts down automatically after <%= idleTimeoutLabel %> of inactivity.<% } %></p>
-                <p class="lead" style="margin-top: 8px; font-size: 13px;">Live service status is reported by <a href="<%= serverUrl %>/health"><%= serverUrl %>/health</a>.</p>
-            </div>
-            <div data-no-md style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; flex-shrink: 0;">
-                <a class="status-badge" href="/llms.txt" target="_blank" rel="noopener noreferrer">
-                    <span class="status-icon">📄</span>
-                    <span>/llms.txt</span>
-                </a>
-                <div class="status-badge" id="shutdownBadge" style="display: none;" title="Time remaining before automatic idle shutdown">
-                    <span class="status-icon">⏻</span>
-                    <span id="shutdownText" class="countdown"></span>
+                <div class="hero-badges">
+                    <a data-no-md class="status-badge" href="/llms.txt" target="_blank" rel="noopener noreferrer">
+                        <span class="status-icon">📄</span>
+                        <span>/llms.txt</span>
+                    </a>
+                    <div data-no-md class="status-badge" id="shutdownBadge" style="display: none;" title="Time remaining before automatic idle shutdown">
+                        <span class="status-icon">⏻</span>
+                        <span id="shutdownText" class="countdown"></span>
+                    </div>
+                    <%# The status badge is deliberately NOT marked data-no-md: it is kept in %>
+                    <%# /llms.txt purely so the /health URL is still surfaced to LLMs now that %>
+                    <%# the visible "service status" sentence has been removed. %>
+                    <a class="status-badge loading" id="statusBadge" href="<%= serverUrl %>/health" target="_blank" rel="noopener noreferrer"><span class="status-dot"></span><span id="statusText">Checking...</span></a>
+                    <% if (isLocalMode) { %>
+                        <div data-no-md class="badge"><%= modeLabel %></div>
+                    <% } %>
                 </div>
-                <a class="status-badge loading" id="statusBadge" href="/health" target="_blank" rel="noopener noreferrer">
-                    <span class="status-dot"></span>
-                    <span id="statusText">Checking...</span>
-                </a>
-                <% if (isLocalMode) { %>
-                    <div class="badge"><%= modeLabel %></div>
-                <% } %>
             </div>
+            <p class="lead">An Actor for secure execution of arbitrary code. Connect using MCP, REST API, or interactive shell.<% if (idleTimeoutSecs > 0) { %> The Actor shuts down automatically after <%= idleTimeoutLabel %> of inactivity.<% } %></p>
         </header>
 
         <section class="card">

--- a/sandbox/src/templates/landing.ts
+++ b/sandbox/src/templates/landing.ts
@@ -31,7 +31,11 @@ const landingTemplate = readFileSync(templatePath, 'utf8');
 const stylesPath = join(dirname(fileURLToPath(import.meta.url)), 'landing.css');
 const landingStyles = readFileSync(stylesPath, 'utf8');
 
-const STRIP_SELECTOR = 'script, style, [data-no-md], .copy-btn, .status-badge';
+// `.status-badge` is intentionally not stripped here: the health-status badge is
+// kept in /llms.txt so the /health URL stays discoverable. Badges that should not
+// appear in the Markdown (the /llms.txt link, the idle countdown) are tagged
+// data-no-md in the template instead.
+const STRIP_SELECTOR = 'script, style, [data-no-md], .copy-btn';
 
 const nhm = new NodeHtmlMarkdown(
     {


### PR DESCRIPTION
- Stack the hero vertically so the intro paragraph uses the full card width instead of being squeezed into the column beside the status badges.
- Drop the "Live service status is reported by …/health" sentence; the health badge now carries the `/health` link into `/llms.txt`, so the endpoint stays discoverable for LLMs without the extra on-page copy.

https://claude.ai/code/session_01CtbYvcQy2ui4e4m8BjEQTs