### PR TITLE
Restructure sandbox README around the landing-page blocks

### DIFF
--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -1,429 +1,148 @@
 # Apify AI Code Sandbox
 
-Isolated sandbox for running AI coding operations in a containerized environment. 🚀
+Secure, isolated container for executing arbitrary code — built for AI coding agents and untrusted code. Connect over **MCP**, a **REST API**, or an **interactive browser shell**. Ships with **Claude Code**, **Codex CLI**, and **OpenCode** pre-configured and ready to launch. 🚀
+
+> 💡 Open the Actor's **landing page** (the container URL, shown in the run log and Actor output) for live connection details, one-click shell/agent launches, a health badge, and the idle-shutdown countdown. The same docs are served as machine-readable Markdown at `/llms.txt`.
 
 ## Use cases
 
-- **🔒 Execute untrusted code safely:** Run potentially unsafe code in an isolated container with controlled resources and security boundaries
-- **🤖 AI agent development:** Provide isolated and managed development environments where AI agents can code, test, and execute operations securely
-- **📦 Sandboxed operations:** Execute system commands, file operations, and custom scripts in a contained environment
-- **🖥️ Interactive debugging:** Access the sandbox via browser-based shell terminal for real-time exploration and troubleshooting
-- **🔀 Bridges:** Expose local services (web servers, APIs, dashboards) running inside the container to external URL paths - accessible from outside the container
-- **🔗 Apify Actor orchestration:** Agents can access the limited permissions Apify token (available as `APIFY_TOKEN` env var) to run other [limited permissions Actors](https://docs.apify.com/platform/actors/development/permissions), process or analyze their output, and build complex data pipelines by combining results from multiple Actors
+- **Run untrusted or AI-generated code safely** in an isolated container with controlled resources.
+- **Give AI agents a managed workspace** to write, run, and test code — with state that survives container migrations.
+- **Drop in over MCP** so any MCP client gains code-execution and filesystem tools, no glue code.
+- **Pair with coding agents** (Claude Code, Codex CLI, OpenCode) right in the browser shell.
+- **Expose internal services** (dev servers, dashboards, TUIs) at a public URL with bridges.
+- **Orchestrate Apify Actors** using the limited-permission `APIFY_TOKEN` available inside the sandbox to run other [limited-permission Actors](https://docs.apify.com/platform/actors/development/permissions) and build data pipelines.
 
 ## Quickstart
 
-### Start the Actor
+1. Run the Actor on the [Apify platform](https://console.apify.com/) (Console or API).
+2. Open the **landing page** — the container URL from the run log / Actor output — for live links and connection details.
+3. Connect with an MCP client, call the REST API, or open the shell.
 
-1. Run it on the Apify platform through the [Console](https://console.apify.com/)
-2. Check the Actor run log console for connection details (host, port, MCP endpoint URL)
-3. Open the landing page link from the run logs for connection details, quick links (shell + health), and endpoint URLs for the current run.
+Examples below use `https://UNIQUE-ID.runs.apify.net` as the container URL — replace it with your run's URL.
 
-## Ways to connect
+## 🖥️ Interactive shell — `/shell`
 
-Start the Actor (see Quickstart above), then choose how to interact:
+Browser terminal (powered by ttyd) for hands-on work inside the sandbox.
 
-- MCP client: Agent-driven access to run code or develop with LLM tooling.
-- REST API: Endpoints to run code or shell commands.
-- Interactive shell: Browser terminal for manual exploration.
+- `…/shell` — plain Bash shell.
+- `…/shell?launch=claude` — launch **Claude Code**.
+- `…/shell?launch=codex` — launch **Codex CLI**.
+- `…/shell?launch=opencode` — launch **OpenCode**.
+- `…/shell?launch=<command>` — run any command, then drop into a shell.
 
-### MCP client
+The coding agents are installed on first use and start pre-configured against the Apify OpenRouter proxy (billed as OpenRouter API usage).
 
-Use a Model Context Protocol (MCP) client to interact with this sandbox. See [modelcontextprotocol.io/clients](https://modelcontextprotocol.io/clients).
+## 📡 Connect with MCP — `/mcp`
 
-**Connect with Claude Code:**
+Streamable-HTTP MCP endpoint, no authentication required:
+
+```
+https://UNIQUE-ID.runs.apify.net/mcp
+```
+
+Add it to a client:
 
 ```bash
 claude mcp add --transport http sandbox https://UNIQUE-ID.runs.apify.net/mcp
+codex mcp add sandbox --url https://UNIQUE-ID.runs.apify.net/mcp
+mcpc connect https://UNIQUE-ID.runs.apify.net/mcp @sandbox
 ```
 
-Replace `UNIQUE-ID` with the run ID from your Actor execution (URL is also in the landing page and logs). Then prompt your agent; it will use the sandbox tools automatically over MCP.
+Tools exposed: `execute` (shell / JS / TS / Python), `read-file`, `write-file`, `list-files`.
 
-### REST API
+## ⚡ Code execution API — `/exec`
 
-Available endpoints (all URLs come from the run logs/landing page):
+`POST /exec` runs a shell command or a code snippet.
 
-#### Core endpoints
-
-- `POST /mcp`
-    - Body: JSON-RPC over HTTP per MCP client
-    - Returns: JSON-RPC response
-
-- `POST /exec`
-    - Execute shell commands OR code snippets (JavaScript, TypeScript, Python)
-    - Body: `{ command: string; language?: string; cwd?: string; timeoutSecs?: number }`
-    - Language options: `"js"`, `"javascript"`, `"ts"`, `"typescript"`, `"py"`, `"python"`, `"bash"`, `"sh"` (omit for shell)
-    - Returns (200 on success, 500 on error): `{ stdout: string; stderr: string; exitCode: number; language: string }`
-    - The `language` field in response is always present: `"shell"` for shell commands, `"js"`/`"ts"`/`"py"` for code
-
-- `GET /health`
-    - Health check endpoint
-    - Returns (200/503): `{ status: 'healthy' | 'initializing' | 'unhealthy'; message?: string }`
-
-- `GET /shell/`
-    - Interactive browser terminal
-    - Returns: Interactive terminal powered by ttyd
-
-- `GET /llms.txt`
-    - Markdown documentation for LLMs (same usage info as landing page)
-    - Returns (200): Plain text Markdown with all endpoint documentation
-
-#### Bridge endpoints
-
-Expose local services running inside the container to external URL paths. This allows you to start a web server (e.g., on port 3000) inside the sandbox and access it from outside via a bridge.
-
-- `GET /bridges`
-    - List current bridges
-    - Returns (200): `{ bridges: [{ path: string, target: string }] }`
-
-- `PUT /bridges`
-    - Replace all bridges
-    - Body: `{ bridges: [{ path: "/myapp", target: "http://127.0.0.1:3000/myapp" }] }`
-    - Returns (200): `{ success: true, bridges: [...] }`
-
-- `POST /bridges`
-    - Add a single bridge
-    - Body: `{ path: "/myapp", target: "http://127.0.0.1:3000/myapp" }`
-    - Returns (200): `{ success: true, bridges: [...] }`
-
-- `DELETE /bridges/{path}`
-    - Remove a bridge by path
-    - Returns (200): `{ success: true, removed: string, bridges: [...] }`
-
-Once configured, all HTTP requests and WebSocket connections to the bridge (e.g., `/myapp/*`) are transparently forwarded to the local service. Bridges can also be configured via Actor input or by writing to `/sandbox/.bridges.json`.
-
-**Health status:**
-
-- `status: "initializing"` (503) – dependencies/setup still running
-- `status: "unhealthy"` (503) – init script failed; check logs
-- `status: "healthy"` (200) – ready for requests
-
-#### RESTful filesystem endpoints
-
-Direct filesystem access using standard HTTP methods. All paths are relative to `/sandbox`.
-
-- `GET /fs/{path}`
-    - **Read file**: Returns raw file bytes with appropriate `Content-Type` header
-    - **List directory**: Returns JSON with directory contents (files and subdirectories with sizes)
-    - Query params:
-        - `?download=1`: Download file as attachment (or directory as ZIP)
-    - Returns (200): File content or directory JSON, (404): Path not found
-
-- `PUT /fs/{path}`
-    - **Write/replace file**: Create or replace file with request body content
-    - Accepts raw bytes or text in request body
-    - Automatically creates parent directories if they don't exist
-    - Returns (200): `{ success: true, path: string, size: number }`
-
-- `POST /fs/{path}?mkdir=1`
-    - **Create directory**: Create directory at specified path (recursive by default)
-    - Returns (201): `{ success: true, path: string, type: "directory" }`
-
-- `POST /fs/{path}?append=1`
-    - **Append to file**: Append request body to existing file (creates file if it doesn't exist)
-    - Returns (200): `{ success: true, path: string, size: number }`
-
-- `DELETE /fs/{path}`
-    - **Delete file or directory**
-    - Query params:
-        - `?recursive=1`: Enable recursive deletion for non-empty directories
-    - Returns (200): `{ success: true, path: string, deleted: true }`, (409): Directory not empty
-
-- `HEAD /fs/{path}`
-    - **Get metadata**: Returns file/directory metadata in response headers
-    - Headers: `Content-Type`, `Content-Length`, `X-File-Type`, `Last-Modified`, `X-Path`
-    - Returns (200): Headers only, (404): Path not found
-
-**Path Resolution**: All `/fs/*` paths are resolved relative to `/sandbox`:
-
-- `/fs/app/main.py` → `/sandbox/app/main.py`
-- `/fs/tmp/test.txt` → `/sandbox/tmp/test.txt`
-
-**Security**: Paths are validated to prevent escaping the `/sandbox` directory. Symlinks are followed but validated to stay within `/sandbox`.
-
-**Filesystem examples (curl):**
+- Body: `{ command: string; language?: string; cwd?: string; timeoutSecs?: number }`
+- `language`: `bash`/`sh` (or omit) for shell; `js`/`javascript`, `ts`/`typescript`, `py`/`python` for code.
+- Returns `{ stdout, stderr, exitCode, language }` — `200` on success, `500` on a non-zero exit or error.
 
 ```bash
-# Read a file
-curl https://UNIQUE-ID.runs.apify.net/fs/app/config.json
-
-# List directory contents
-curl https://UNIQUE-ID.runs.apify.net/fs/app
-
-# Download directory as ZIP
-curl https://UNIQUE-ID.runs.apify.net/fs/app?download=1 -o app.zip
-
-# Upload a file
-curl -X PUT https://UNIQUE-ID.runs.apify.net/fs/app/config.json \
+curl -X POST https://UNIQUE-ID.runs.apify.net/exec \
   -H "Content-Type: application/json" \
-  -d '{"key": "value"}'
-
-# Create a directory
-curl -X POST https://UNIQUE-ID.runs.apify.net/fs/app/data?mkdir=1
-
-# Append to a log file
-curl -X POST https://UNIQUE-ID.runs.apify.net/fs/app/log.txt?append=1 \
-  -H "Content-Type: text/plain" \
-  -d "New log entry"
-
-# Delete a file
-curl -X DELETE https://UNIQUE-ID.runs.apify.net/fs/app/temp.txt
-
-# Delete directory recursively
-curl -X DELETE https://UNIQUE-ID.runs.apify.net/fs/app/temp?recursive=1
-
-# Get file metadata
-curl -I https://UNIQUE-ID.runs.apify.net/fs/app/data.json
+  -d '{"command": "print(\"hi\")", "language": "py", "timeoutSecs": 10}'
 ```
 
-**Upload/download files (TypeScript):**
+Default working directories: shell → `/sandbox`, JS/TS → `/sandbox/js-ts`, Python → `/sandbox/py`. Override with `cwd` (must stay within `/sandbox`).
 
-```ts
-const baseUrl = 'https://UNIQUE-ID.runs.apify.net';
+## 📁 Filesystem API — `/fs`
 
-// Upload a file
-const uploadResponse = await fetch(`${baseUrl}/fs/app/document.pdf`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/pdf' },
-    body: pdfBuffer, // File buffer or Blob
-});
+Direct file operations over HTTP. All paths are relative to `/sandbox` and validated to stay inside it.
 
-// Download a file
-const downloadResponse = await fetch(`${baseUrl}/fs/app/document.pdf`);
-const fileBlob = await downloadResponse.blob();
-
-// Download directory as ZIP
-const zipResponse = await fetch(`${baseUrl}/fs/app?download=1`);
-const zipBlob = await zipResponse.blob();
-
-// List directory
-const listResponse = await fetch(`${baseUrl}/fs/app`);
-const { entries } = await listResponse.json();
-console.log(entries); // [{ name, type, size }, ...]
-
-// Create project structure
-await fetch(`${baseUrl}/fs/project/src?mkdir=1`, { method: 'POST' });
-await fetch(`${baseUrl}/fs/project/tests?mkdir=1`, { method: 'POST' });
-await fetch(`${baseUrl}/fs/project/README.md`, {
-    method: 'PUT',
-    body: '# My Project',
-});
-```
-
-**Upload/download files (Python):**
-
-```python
-import requests
-
-base_url = "https://UNIQUE-ID.runs.apify.net"
-
-# Upload a file
-with open('document.pdf', 'rb') as f:
-    resp = requests.put(f"{base_url}/fs/app/document.pdf",
-                       data=f,
-                       headers={'Content-Type': 'application/pdf'})
-    resp.raise_for_status()
-
-# Download a file
-resp = requests.get(f"{base_url}/fs/app/document.pdf")
-with open('downloaded.pdf', 'wb') as f:
-    f.write(resp.content)
-
-# Download directory as ZIP
-resp = requests.get(f"{base_url}/fs/app?download=1")
-with open('app.zip', 'wb') as f:
-    f.write(resp.content)
-
-# List directory
-resp = requests.get(f"{base_url}/fs/app")
-data = resp.json()
-for entry in data['entries']:
-    print(f"{entry['name']} ({entry['type']}) - {entry.get('size', 'N/A')} bytes")
-
-# Create project structure
-requests.post(f"{base_url}/fs/project/src?mkdir=1")
-requests.post(f"{base_url}/fs/project/tests?mkdir=1")
-requests.put(f"{base_url}/fs/project/README.md", data=b"# My Project")
-```
-
-**Code execution examples (TypeScript/Node):**
-
-```ts
-const baseUrl = 'https://UNIQUE-ID.runs.apify.net';
-
-// Execute Python code
-const codeRes = await fetch(`${baseUrl}/exec`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({
-        command: 'print("hello from python")',
-        language: 'py',
-        timeoutSecs: 10,
-    }),
-});
-console.log(await codeRes.json());
-
-// Execute shell command
-const shellRes = await fetch(`${baseUrl}/exec`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({
-        command: 'ls -la',
-        cwd: '/sandbox',
-        timeoutSecs: 5,
-    }),
-});
-console.log(await shellRes.json());
-```
-
-**Code execution examples (Python):**
-
-```python
-import requests
-
-base_url = "https://UNIQUE-ID.runs.apify.net"
-
-# Execute Python code
-payload = {"command": "print('hello from python')", "language": "py", "timeoutSecs": 10}
-resp = requests.post(f"{base_url}/exec", json=payload, timeout=15)
-resp.raise_for_status()
-print(resp.json())
-
-# Execute shell command
-payload = {"command": "ls -la", "cwd": "/sandbox", "timeoutSecs": 5}
-resp = requests.post(f"{base_url}/exec", json=payload, timeout=15)
-resp.raise_for_status()
-print(resp.json())
-```
-
-### Interactive shell terminal
-
-Open the interactive shell terminal URL from the run logs (also linked on the landing page) to work directly in the browser.
-
-### Bridges
-
-Expose local services running inside the container to external URL paths. Start a web server inside the sandbox and access it from outside the container.
-
-**Example workflow:**
+- `GET /fs/{path}` — read a file (raw bytes) or list a directory (JSON `{ path, entries }`). Add `?download=1` to get a file as an attachment or a directory as a ZIP.
+- `PUT /fs/{path}` — write/replace a file (creates parent dirs; up to 500 MB).
+- `POST /fs/{path}?mkdir=1` — create a directory; `?append=1` — append to a file.
+- `DELETE /fs/{path}` — delete; add `?recursive=1` for non-empty directories.
+- `HEAD /fs/{path}` — return metadata in the response headers.
 
 ```bash
-# 1. Start a local web server inside the sandbox
-npx http-server /sandbox/myapp -p 8080
+curl https://UNIQUE-ID.runs.apify.net/fs/app/log.txt                            # read
+curl -X PUT https://UNIQUE-ID.runs.apify.net/fs/config.json -d '{"key":"value"}' # write
+curl -X POST "https://UNIQUE-ID.runs.apify.net/fs/project/src?mkdir=1"           # mkdir
+curl -X DELETE "https://UNIQUE-ID.runs.apify.net/fs/temp?recursive=1"            # delete
+```
 
-# 2. Add a bridge (via REST API)
+Prefer a UI? Browse the filesystem at `/browse`.
+
+## 🔀 Bridges — `/bridges`
+
+Expose a web server you start **inside** the sandbox at a public URL path on the container, reachable over HTTP and WebSocket. Each bridge forwards `…/{path}` → `http://127.0.0.1:{port}/…`.
+
+- `GET /bridges` — list current bridges.
+- `POST /bridges` — add one: `{ "path": "/myapp", "target": "http://127.0.0.1:3000/myapp" }`.
+- `PUT /bridges` — replace all: `{ "bridges": [ … ] }`.
+- `DELETE /bridges/{path}` — remove one.
+
+```bash
+# Start a server inside the sandbox, then expose it:
 curl -X POST https://UNIQUE-ID.runs.apify.net/bridges \
   -H "Content-Type: application/json" \
   -d '{"path": "/myapp", "target": "http://127.0.0.1:8080"}'
-
-# 3. Access the app from outside
-# https://UNIQUE-ID.runs.apify.net/myapp/
+# Now reachable at https://UNIQUE-ID.runs.apify.net/myapp/
 ```
 
-**Via Actor input:**
+Bridges can also be set via the `bridges` input or by writing `/sandbox/.bridges.json` (changes are picked up live). Longest-path matching and `Location`-header rewriting are automatic, and bridges persist across restarts.
 
-Provide bridges at startup via the `bridges` input parameter:
+## Health & status — `/health`
 
-```json
-[{"path": "/myapp", "target": "http://127.0.0.1:3000/myapp"}]
-```
+`GET /health` reports the service state:
 
-**Via config file:**
+- `200 { status: "healthy", idleTimeoutSecs, remainingSecs? }`
+- `503 { status: "initializing" }` — dependencies / setup script still running.
+- `503 { status: "unhealthy", message }` — setup failed; check the run log.
 
-Bridges can also be modified by writing JSON to `/sandbox/.bridges.json`. Changes are detected automatically via file watching.
-
-**Features:**
-- Supports both HTTP and WebSocket connections
-- Longest-path matching for overlapping routes
-- Automatic redirect rewriting (Location headers)
-- Live reload on config file changes
+`remainingSecs` counts down to idle shutdown and is present only while an idle timeout is active.
 
 ## Configuration
 
-- **Memory & timeout:** Configure run options to set memory allocation and execution timeout
-- **Idle timeout:** The container automatically shuts down after a period of inactivity (default: 15 minutes). Activity includes HTTP requests and shell interaction. You can adjust this via the `idleTimeoutSecs` input.
-- **Recommendation:** For cost efficiency, set the standard Actor **Execution Timeout to 0 (infinite)** in the Apify Console. The internal idle logic will then manage the lifecycle based on your usage.
-- **Request timeout:** All requests to the Actor have a 5-minute timeout ceiling. All operations (code execution, commands, file operations) must complete within this time limit. The `timeout` parameter in requests cannot exceed this 5-minute window
-- **Check logs:** Open the Actor run log console to view connection details and operation output
+All inputs are optional. Set them in the Actor input form or via the API.
 
-## Sandbox environment structure
+| Input                                          | Description                                                                                                                                                             |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Agent skills** (`agentSkills`)               | SKILLS.md packages for the coding agents — `owner/repo` or a repo URL per line, or a JSON array. Defaults to `apify/agent-skills`. See [skills.sh](https://skills.sh/). |
+| **Node.js dependencies** (`nodeDependencies`)  | npm packages for JS/TS execution. One `package@version` per line (npm-style), or a `package.json`-style JSON object.                                                    |
+| **Python requirements** (`pythonRequirements`) | pip packages for Python execution, in `requirements.txt` format.                                                                                                        |
+| **MCP connectors** (`mcpConnectors`)           | MCP connectors to pre-load into Claude Code, Codex, and OpenCode, and write to `/sandbox/mcp.json` for `mcpc`.                                                          |
+| **Setup script** (`initBashScript`)            | Bash script run on startup after dependencies install. Output streams to the log (tagged `[init]`) with a progress heartbeat; 5-minute timeout.                         |
+| **Environment variables** (`envVars`)          | Secret variables exposed **only to the setup script**, then removed before the shell, MCP server, and code execution start. dotenv or JSON; encrypted at rest.          |
+| **Idle timeout** (`idleTimeoutSecs`)           | Seconds of inactivity before automatic shutdown (default `900`; `0` disables). Activity includes HTTP requests and shell interaction.                                   |
+| **Bridges** (`bridges`)                        | Bridges to create at startup (see above).                                                                                                                               |
 
-The sandbox runs on a **Debian Trixie** container image with **Node.js 24**, **Python 3**, and essential development tools pre-installed.
+Dependencies install at startup before any code runs. For cost efficiency, set the Actor's **Execution Timeout to 0 (infinite)** and let the idle timeout manage the lifecycle. Note that every request to the Actor has a 5-minute ceiling, so each operation must finish within that window.
 
-The sandbox provides isolated execution environments for different code languages:
+## Sandbox environment
 
-### Code execution directories
-
-- **Python**: `/sandbox/py`
-    - Python code executes in this isolated directory
-    - Has access to Python virtual environment at `/sandbox/py/venv`
-    - All pip packages installed in the venv
-
-- **JavaScript/TypeScript**: `/sandbox/js-ts`
-    - JS/TS code executes in this isolated directory
-    - Has access to node_modules at `/sandbox/js-ts/node_modules`
-    - All npm packages installed in node_modules
-
-- **General Commands**: `/sandbox` (root)
-    - Shell commands via `/exec` endpoint run from sandbox root
-    - Can access all subdirectories
-
-### Dependency installation
-
-Specify dependencies to install via Actor input:
-
-- **Node.js Dependencies**: npm packages for JS/TS code execution. Accepts either format:
-    - **One `package@version` per line** (npm CLI style):
-        ```
-        zod@^3.0
-        axios@latest
-        lodash
-        @types/node@^20
-        ```
-        Lines without `@version` default to `latest`. Blank lines and `#` comments are ignored.
-    - **JSON object** (package.json `dependencies` style): `{"zod": "^3.0", "axios": "latest"}`
-- **Python Requirements**: pip packages for Python code execution in requirements.txt format
-    - Input as multi-line text: one package per line with optional version specifiers
-    - Example:
-        ```
-        requests==2.31.0
-        pandas>=2.0.0
-        numpy
-        ```
-
-Dependencies are installed during Actor startup before any code execution, allowing your code to immediately use them.
-
-### Customization with init script
-
-Provide a bash script via the "Initialization Script" input to customize the sandbox:
-
-- Runs **after** library installation
-- Executes in `/sandbox` directory
-- Can install system packages, create directories, set permissions, etc.
-- Output is streamed live to the Actor log (tagged `[init]`), with a progress heartbeat for long steps, so you can follow along and debug failures
-- Errors are logged but don't prevent Actor from starting
-- **Note:** Init scripts have a 5-minute execution timeout
-
-**Example init scripts:**
-
-```bash
-# Install system package
-apt-get update && apt-get install -y curl
-
-# Create custom directory with permissions
-mkdir -p /sandbox/custom-data && chmod 755 /sandbox/custom-data
-```
-
-### Skills support (SKILLS.md)
-
-Install skill packages that provide specialized instructions for AI coding agents. Skills are SKILLS.md files that enhance agent capabilities.
-
-- Specify skills via the "Skills" input — one per line: a GitHub `owner/repo` (e.g. `anthropics/skills`) or repo URL (e.g. `https://github.com/anthropics/skills`), or a JSON array
-- Example: `apify/agent-skills`
-- Skills are installed globally during Actor startup
-- For more info see [skills.sh](https://skills.sh/)
+- **Base image:** Debian Trixie with **Node.js 24** and **Python 3** (`venv` at `/sandbox/py/venv`).
+- **Pre-installed tools:** git, openssh-client, curl, wget, jq, build-essential, `tsx`, `apify-cli`, `mcpc`, and `ttyd`; `apify-client` is ready in both the Node and Python environments.
+- **Coding agents:** Claude Code, Codex CLI, and OpenCode — installed on first launch and wired to the Apify OpenRouter proxy (authenticated with `APIFY_TOKEN`).
+- **Working directories:** `/sandbox` (shell), `/sandbox/js-ts` (npm packages in `node_modules`), `/sandbox/py` (Python venv).
+- **Persistence:** filesystem changes are backed up to the Actor's key-value store and restored after a container migration, so work survives restarts (dependency directories are excluded and reinstalled).
+- **Agent context:** `AGENTS.md` and `CLAUDE.md` are placed in `/sandbox` to guide the coding agents.
 
 ## Learn more
 
-- [Apify Actor documentation](https://docs.apify.com/platform/actors)
+- [Apify Actors documentation](https://docs.apify.com/platform/actors)
 - [Model Context Protocol](https://modelcontextprotocol.io/)
 - [Apify SDK reference](https://docs.apify.com/sdk)


### PR DESCRIPTION
Rewrites `sandbox/README.md` to follow the same blocks as the landing page (Interactive shell, Connect with MCP, Code execution API, Filesystem API, Bridges) so the docs and the home page stay in sync.

- Documents features that had shipped but were missing from the README: shell agent launchers (`?launch=`), MCP client setup + tool names, `/browse`, `/llms.txt`, the `envVars` and `mcpConnectors` inputs, input renames, and cross-migration persistence.
- Fixes stale `envVars` docs — it's exposed only to the setup script, then removed before the shell, MCP server, and code execution.
- Drops the duplicated TypeScript/Python example blocks in favour of concise curl examples (matching the home page); ~370 lines lighter and Prettier-clean.

https://claude.ai/code/session_01G9qRHY5MwEmvbggrwbwVZ4