### PR TITLE
Relabel /llms.txt health link and link the Actor page in the lead

### DIFF
--- a/sandbox/src/main.ts
+++ b/sandbox/src/main.ts
@@ -236,6 +236,9 @@ app.use((req, _res, next) => {
         });
     }
 
+    // Any non-health request — including doc fetches like /llms.txt — counts as
+    // activity and pushes back the idle-shutdown timer. Only /health and the
+    // readiness probe are excluded, since they fire automatically.
     if (!isHealth && !isProbe) {
         lastActivityAt = Date.now();
     }

--- a/sandbox/src/templates/landing.css
+++ b/sandbox/src/templates/landing.css
@@ -379,6 +379,11 @@ a.status-badge:hover {
     font-size: 12px;
     line-height: 1;
 }
+/* Rendered only in the generated /llms.txt Markdown (where CSS doesn't apply);
+   hidden in the live page, which shows the JS-driven status text instead. */
+.md-only {
+    display: none;
+}
 /* Keep countdown digits fixed-width so the badge doesn't jiggle as it ticks */
 .countdown {
     font-variant-numeric: tabular-nums;

--- a/sandbox/src/templates/landing.ejs
+++ b/sandbox/src/templates/landing.ejs
@@ -21,16 +21,17 @@
                         <span class="status-icon">⏻</span>
                         <span id="shutdownText" class="countdown"></span>
                     </div>
-                    <%# The status badge is deliberately NOT marked data-no-md: it is kept in %>
-                    <%# /llms.txt purely so the /health URL is still surfaced to LLMs now that %>
-                    <%# the visible "service status" sentence has been removed. %>
-                    <a class="status-badge loading" id="statusBadge" href="<%= serverUrl %>/health" target="_blank" rel="noopener noreferrer"><span class="status-dot"></span><span id="statusText">Checking...</span></a>
+                    <%# The status-badge link is kept in /llms.txt so the /health URL stays %>
+                    <%# discoverable by LLMs. The live "Checking..." text is page-only %>
+                    <%# (data-no-md, swapped out by JS); the Markdown shows a static %>
+                    <%# "Health check" label via the .md-only span instead. %>
+                    <a class="status-badge loading" id="statusBadge" href="<%= serverUrl %>/health" target="_blank" rel="noopener noreferrer"><span class="status-dot"></span><span id="statusText" data-no-md>Checking...</span><span class="md-only">Health check</span></a>
                     <% if (isLocalMode) { %>
                         <div data-no-md class="badge"><%= modeLabel %></div>
                     <% } %>
                 </div>
             </div>
-            <p class="lead">An Actor for secure execution of arbitrary code. Connect using MCP, REST API, or interactive shell.<% if (idleTimeoutSecs > 0) { %> The Actor shuts down automatically after <%= idleTimeoutLabel %> of inactivity.<% } %></p>
+            <p class="lead">An <a href="https://apify.com/apify/ai-code-sandbox" target="_blank" rel="noopener noreferrer">Actor</a> for secure execution of arbitrary code. Connect using MCP, REST API, or interactive shell.<% if (idleTimeoutSecs > 0) { %> The Actor shuts down automatically after <%= idleTimeoutLabel %> of inactivity.<% } %></p>
         </header>
 
         <section class="card">


### PR DESCRIPTION
- `/llms.txt` now shows a `Health check` link to `/health` instead of the live page's transient `Checking…` text (kept page-only via `data-no-md`).
- The hero lead now links **Actor** to https://apify.com/apify/ai-code-sandbox.
- Verified that fetching `/llms.txt` already resets the idle-shutdown timer (health `remainingSecs` went 896 → 900 right after a fetch); added a comment to document the intent — no logic change needed.

https://claude.ai/code/session_01N3HNsUofRw1jgDG6Xq6Z7G

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3HNsUofRw1jgDG6Xq6Z7G)_