### PR TITLE
Refactor main.ts: extract routes and server logic into modules

### DIFF
--- a/sandbox/.actor/actor.json
+++ b/sandbox/.actor/actor.json
@@ -93,7 +93,7 @@
                     "required": ["path", "target"]
                 },
                 "default": [],
-                "prefill": [{"path": "/myapp", "target": "http://127.0.0.1:3000/myapp"}]
+                "prefill": [{ "path": "/myapp", "target": "http://127.0.0.1:3000/myapp" }]
             }
         },
 

--- a/sandbox/AGENTS.md
+++ b/sandbox/AGENTS.md
@@ -309,17 +309,43 @@ Ask first:
 .actor/
 ├── actor.json                    # Actor configuration (name, version, input schema)
 scripts/
+├── agent-launchers.sh            # Shell functions that install-then-run the coding agents
 └── capture-versions.sh           # Build-time version capture script (runs in Dockerfile)
                                   # Caches tool versions to /app/.versions/*.txt for fast shell startup
 src/
-├── main.ts                       # Express HTTP server & Actor initialization
-├── mcp.ts                        # Model Context Protocol (MCP) server
-├── operations.ts                 # Core execution operations (shell, Python, Node.js)
-├── environment.ts                # Sandbox environment setup & library installation
+├── main.ts                       # Entrypoint: startup sequence + HTTP server assembly (wiring only)
+├── routes/
+│   ├── fs.ts                     # /fs RESTful filesystem API
+│   ├── bridges.ts                # /bridges CRUD API
+│   ├── exec.ts                   # /exec command & code execution endpoint
+│   └── mcp.ts                    # /mcp Streamable HTTP transport endpoint
+├── operations.ts                 # Execution & filesystem operations (shared by REST and MCP)
+├── mcp.ts                        # MCP server tool definitions
+├── mcp-connections.ts            # Writes /sandbox/mcp.json from the MCP Connector input
+├── mcp-agent-config.ts           # Loads MCP Connectors into Claude Code / Codex / OpenCode configs
+├── shell-server.ts               # ttyd process supervision + /shell HTTP & WebSocket proxy
+├── shell-launch.ts               # /shell `?launch=<cmd>` → ttyd `?arg=...` URL translation (pure)
+├── ttyd.ts                       # ttyd restart/backoff/crash decision helpers (pure)
+├── bridges.ts                    # Bridge configuration store (file-watched, persisted)
+├── bridge-proxy.ts               # Live reverse proxies serving bridged HTTP/WebSocket traffic
+├── environment.ts                # Sandbox env setup, dependency installation, init script
+├── persistence.ts                # Migration state save/restore across platform migrations
+├── idle.ts                       # Activity tracking + idle auto-shutdown
+├── status.ts                     # Actor run status messages (best-effort)
+├── env-vars.ts                   # envVars input parser
+├── node-deps.ts                  # nodeDependencies input parser
+├── skills.ts                     # agentSkills input parser
+├── safe-json.ts                  # Tolerant JSON parsing for user-supplied input
+├── route-params.ts               # Express 5 wildcard param → path helper
 ├── types.ts                      # TypeScript type definitions and interfaces
-└── consts.ts                     # Constants and configuration values
+├── consts.ts                     # Constants and configuration values
+└── templates/
+    ├── landing.ts/.ejs/.css      # Landing page + /llms.txt rendering
+    ├── browse.ts                 # /browse filesystem browser SPA
+    └── shell.ts                  # Bash scripts (bashrc, welcome) + terminal reconnect overlay
 tests/
-└── e2e.ts                        # E2E platform tests (deployment + 47 endpoint tests)
+├── unit/*.test.ts                # Unit tests for the pure modules (run in Docker build)
+└── e2e.ts                        # E2E platform tests (deployment + endpoint tests)
 storage/                          # Local storage (mirrors Cloud during development)
 ├── datasets/                     # Output items (JSON objects)
 ├── key_value_stores/             # Files, config, INPUT

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -15,7 +15,6 @@ This Actor launches a web server on the Actor container URL that provides interf
 - 🌐 **Expose internal services** (dev servers, dashboards, TUIs) at a public URL with bridges.
 - 🎭 **Orchestrate Apify Actors** using the limited-permission `APIFY_TOKEN` available inside the sandbox to run other [limited-permission Actors](https://docs.apify.com/platform/actors/development/permissions) and build data pipelines.
 
-
 ## Quickstart
 
 1. Run the Actor on the [Apify platform](https://console.apify.com/) (Console or API).
@@ -23,7 +22,6 @@ This Actor launches a web server on the Actor container URL that provides interf
 3. Connect with an MCP client, call the REST API, or open the shell.
 
 Examples below use `https://UNIQUE-ID.runs.apify.net` as the container URL — replace it with your run's URL.
-
 
 ## 🖥️ Interactive shell — `/shell`
 
@@ -38,7 +36,6 @@ Browser terminal (powered by ttyd) for hands-on work inside the sandbox.
 The coding agents are installed on first use and start pre-configured against the [Apify OpenRouter proxy](https://apify.com/apify/openrouter),
 billed to your Apify account.
 
-
 ## 🤖 AI agent instructions
 
 The sandbox landing page is also available as Markdown as the `/llms.txt` file:
@@ -46,7 +43,6 @@ The sandbox landing page is also available as Markdown as the `/llms.txt` file:
 ```
 https://UNIQUE-ID.runs.apify.net/llms.txt
 ```
-
 
 ## 📡 Connect with MCP — `/mcp`
 
@@ -82,7 +78,6 @@ curl -X POST https://UNIQUE-ID.runs.apify.net/exec \
 
 Default working directories: shell → `/sandbox`, JS/TS → `/sandbox/js-ts`, Python → `/sandbox/py`. Override with `cwd` (must stay within `/sandbox`).
 
-
 ## 📁 Filesystem API — `/fs`
 
 Direct file operations over HTTP. All paths are relative to `/sandbox` and validated to stay inside it.
@@ -102,7 +97,6 @@ curl -X DELETE "https://UNIQUE-ID.runs.apify.net/fs/temp?recursive=1"           
 
 Prefer a UI? Browse the filesystem at `/browse`.
 
-
 ## 🔀 Bridges — `/bridges`
 
 Expose a web server you start **inside** the sandbox at a public URL path on the container, reachable over HTTP and WebSocket. Each bridge forwards `…/{path}` → `http://127.0.0.1:{port}/…`.
@@ -121,7 +115,6 @@ curl -X POST https://UNIQUE-ID.runs.apify.net/bridges \
 ```
 
 Bridges can also be set via the `bridges` input or by writing `/sandbox/.bridges.json` (changes are picked up live). Longest-path matching and `Location`-header rewriting are automatic, and bridges persist across restarts.
-
 
 ## Health & status — `/health`
 

--- a/sandbox/artifacts/AGENTS.md
+++ b/sandbox/artifacts/AGENTS.md
@@ -117,6 +117,7 @@ Pre-configured and ready:
 The **`APIFY_TOKEN`** environment variable is **already set and ready to use** in your current environment. You can freely use it in any script without additional setup:
 
 **Python:**
+
 ```python
 import os
 token = os.environ['APIFY_TOKEN']  # ✅ Already available - use it directly!
@@ -124,18 +125,21 @@ client = ApifyClient(token)
 ```
 
 **JavaScript/TypeScript:**
+
 ```javascript
-const token = process.env.APIFY_TOKEN;  // ✅ Already available - use it directly!
+const token = process.env.APIFY_TOKEN; // ✅ Already available - use it directly!
 const client = new ApifyClient({ token });
 ```
 
 **Bash/Shell:**
+
 ```bash
 echo $APIFY_TOKEN  # ✅ Already available - use it directly!
 mcpc @apify tools-list --json
 ```
 
 **No setup required:** The token is pre-configured. Just reference it and start building!
+
 - **apify-client** pre-installed:
     - Python: `/sandbox/py/venv` (activated automatically for Python execution)
     - JavaScript/TypeScript: `/sandbox/js-ts/node_modules` (available for JS/TS execution)

--- a/sandbox/src/bridge-proxy.ts
+++ b/sandbox/src/bridge-proxy.ts
@@ -1,0 +1,201 @@
+/**
+ * Reverse proxies backing bridges (exposed path → local server inside the
+ * sandbox). Bridge *configuration* (the path/target list, persisted to
+ * /sandbox/.bridges.json) lives in bridges.ts; this module owns the live
+ * http-proxy instances and routes incoming HTTP requests and WebSocket
+ * upgrades to them.
+ */
+import type { IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
+
+import { log } from 'apify';
+import type { NextFunction, Request, Response } from 'express';
+import httpProxy from 'http-proxy';
+
+import { getBridges, onBridgesChange } from './bridges.js';
+import { touchActivity } from './idle.js';
+import type { Bridge } from './types.js';
+
+/** Live reverse-proxy instance backing one bridge. */
+interface BridgeProxy {
+    proxy: ReturnType<typeof httpProxy.createProxyServer>;
+    targetOrigin: string;
+    targetPath: string;
+}
+
+const bridgeProxies = new Map<string, BridgeProxy>();
+
+/**
+ * Find the bridge whose exposed path is the longest prefix of the request
+ * path, or null when none matches.
+ */
+export const matchBridge = (bridges: Bridge[], requestPath: string): Bridge | null => {
+    let matched: Bridge | null = null;
+    for (const bridge of bridges) {
+        if (requestPath.startsWith(bridge.path) && bridge.path.length > (matched?.path.length ?? 0)) {
+            matched = bridge;
+        }
+    }
+    return matched;
+};
+
+/**
+ * Rewrite a request URL from the exposed bridge path to the target path,
+ * preserving the query string. E.g. with bridge path `/app` targeting
+ * `/myapp`, `/app/users?x=1` becomes `/myapp/users?x=1`. Joins the two path
+ * pieces without doubling or dropping the `/` between them.
+ */
+export const rewriteBridgeUrl = (reqUrl: string, bridgePath: string, targetPath: string): string => {
+    const queryIdx = reqUrl.indexOf('?');
+    const pathOnly = queryIdx >= 0 ? reqUrl.slice(0, queryIdx) : reqUrl;
+    const queryString = queryIdx >= 0 ? reqUrl.slice(queryIdx) : '';
+
+    let extraPath = pathOnly.slice(bridgePath.length);
+    let finalPath = targetPath;
+    if (extraPath) {
+        if (finalPath.endsWith('/') && extraPath.startsWith('/')) {
+            extraPath = extraPath.slice(1);
+        }
+        if (!finalPath.endsWith('/') && !extraPath.startsWith('/')) {
+            finalPath += '/';
+        }
+        finalPath += extraPath;
+    }
+
+    const url = finalPath + queryString;
+    return url.startsWith('/') ? url : `/${url}`;
+};
+
+/** Create or replace the reverse proxy backing a bridge. */
+const setupBridge = (bridge: Bridge): void => {
+    let targetUrl = bridge.target;
+    if (!targetUrl.startsWith('http://') && !targetUrl.startsWith('https://')) {
+        targetUrl = `http://${targetUrl}`;
+    }
+
+    let targetOrigin: string;
+    let targetPath: string;
+    try {
+        const url = new URL(targetUrl);
+        targetOrigin = `${url.protocol}//${url.host}`;
+        // Keep the target path as-is (preserve trailing slash if present)
+        targetPath = url.pathname || '/';
+    } catch {
+        log.error('Invalid bridge target URL', { target: targetUrl });
+        return;
+    }
+
+    bridgeProxies.get(bridge.path)?.proxy.close();
+
+    // The proxy targets just the origin; rewriteBridgeUrl remaps paths per request.
+    const proxy = httpProxy.createProxyServer({
+        target: targetOrigin,
+        changeOrigin: true,
+        // Don't rewrite redirects - we remap paths ourselves below
+        autoRewrite: false,
+    });
+
+    proxy.on('error', (err, _req, res) => {
+        log.error('Bridge proxy error', { path: bridge.path, target: targetUrl, error: err.message });
+        if (res && 'writeHead' in res && !res.headersSent) {
+            res.writeHead(502, { 'Content-Type': 'text/plain' });
+            res.end(`Proxy error: target server at ${targetUrl} not available`);
+        }
+    });
+
+    // Rewrite Location headers in redirects to map target paths back to exposed paths
+    proxy.on('proxyRes', (proxyRes) => {
+        const { location } = proxyRes.headers;
+        if (location && typeof location === 'string' && location.startsWith(targetPath)) {
+            const newLocation = bridge.path + location.slice(targetPath.length);
+            // eslint-disable-next-line no-param-reassign -- mutating proxyRes headers is http-proxy's rewrite API
+            proxyRes.headers.location = newLocation;
+            log.info('Rewrote redirect Location header', { original: location, rewritten: newLocation });
+        }
+    });
+
+    bridgeProxies.set(bridge.path, { proxy, targetOrigin, targetPath });
+    log.info('Bridge proxy configured', { exposedPath: bridge.path, targetOrigin, targetPath });
+};
+
+/** Tear down the reverse proxy for a bridge path. */
+const removeBridgeProxy = (path: string): void => {
+    const entry = bridgeProxies.get(path);
+    if (entry) {
+        entry.proxy.close();
+        bridgeProxies.delete(path);
+        log.info('Bridge proxy removed', { path });
+    }
+};
+
+/**
+ * Create proxies for the currently configured bridges and keep them in sync
+ * with config changes (API updates or edits to /sandbox/.bridges.json).
+ */
+export const initializeBridgeProxies = (): void => {
+    for (const bridge of getBridges()) {
+        setupBridge(bridge);
+    }
+
+    onBridgesChange((newBridges) => {
+        const newPaths = new Set(newBridges.map((b) => b.path));
+        for (const path of bridgeProxies.keys()) {
+            if (!newPaths.has(path)) {
+                removeBridgeProxy(path);
+            }
+        }
+        for (const bridge of newBridges) {
+            setupBridge(bridge);
+        }
+    });
+};
+
+/** Look up the live proxy for the bridge matching a request path. */
+const findProxyEntry = (requestPath: string): { bridge: Bridge; entry: BridgeProxy } | null => {
+    const bridge = matchBridge(getBridges(), requestPath);
+    if (!bridge) return null;
+    const entry = bridgeProxies.get(bridge.path);
+    return entry ? { bridge, entry } : null;
+};
+
+/**
+ * Express middleware forwarding requests on bridged paths to their local
+ * target server. Falls through to the next handler when no bridge matches.
+ */
+export const bridgeRequestHandler = (req: Request, res: Response, next: NextFunction): void => {
+    const match = findProxyEntry(req.path);
+    if (!match) {
+        next();
+        return;
+    }
+
+    req.url = rewriteBridgeUrl(req.url, match.bridge.path, match.entry.targetPath);
+    log.info('Proxying bridged request', {
+        exposedPath: match.bridge.path,
+        targetUrl: match.entry.targetOrigin + req.url,
+    });
+
+    touchActivity();
+    match.entry.proxy.web(req, res);
+};
+
+/**
+ * Proxy a WebSocket upgrade on a bridged path to its target server. Returns
+ * false (untouched request) when no bridge matches.
+ */
+export const handleBridgeUpgrade = (req: IncomingMessage, socket: Duplex, head: Buffer): boolean => {
+    const reqUrl = req.url || '/';
+    const pathOnly = reqUrl.split('?')[0];
+    const match = findProxyEntry(pathOnly);
+    if (!match) return false;
+
+    req.url = rewriteBridgeUrl(reqUrl, match.bridge.path, match.entry.targetPath);
+    log.info('Proxying bridged WebSocket upgrade', {
+        exposedPath: match.bridge.path,
+        targetUrl: match.entry.targetOrigin + req.url,
+    });
+
+    socket.on('data', touchActivity);
+    match.entry.proxy.ws(req, socket, head);
+    return true;
+};

--- a/sandbox/src/bridges.ts
+++ b/sandbox/src/bridges.ts
@@ -3,7 +3,9 @@
  *
  * Manages bridge configuration (exposed path → local service) with file
  * watching for live updates. A bridge exposes a local server running inside
- * the sandbox at a public URL path on the container.
+ * the sandbox at a public URL path on the container. The live reverse proxies
+ * that serve bridged traffic react to these changes via onBridgesChange (see
+ * bridge-proxy.ts).
  */
 
 import { existsSync, mkdirSync, readFileSync, watch, writeFileSync } from 'node:fs';
@@ -18,7 +20,96 @@ import type { Bridge } from './types.js';
 let currentBridges: Bridge[] = [];
 
 // Callbacks to notify when bridges change
-const changeListeners: Array<(bridges: Bridge[]) => void> = [];
+const changeListeners: ((bridges: Bridge[]) => void)[] = [];
+
+/**
+ * Notify all listeners of bridge changes
+ */
+const notifyListeners = (): void => {
+    for (const listener of changeListeners) {
+        try {
+            listener([...currentBridges]);
+        } catch (error) {
+            log.error('Error in bridges change listener', { error: (error as Error).message });
+        }
+    }
+};
+
+/**
+ * Save bridges to config file
+ * @param bridges - Bridges to save
+ */
+export const saveBridges = (bridges: Bridge[]): void => {
+    try {
+        // Ensure directory exists
+        const dir = dirname(BRIDGES_PATH);
+        if (!existsSync(dir)) {
+            mkdirSync(dir, { recursive: true });
+        }
+
+        writeFileSync(BRIDGES_PATH, JSON.stringify(bridges, null, 2));
+        currentBridges = bridges;
+        log.info('Saved bridges to config file', {
+            count: bridges.length,
+            path: BRIDGES_PATH,
+        });
+
+        // Notify listeners
+        notifyListeners();
+    } catch (error) {
+        log.error('Failed to save bridges', { error: (error as Error).message });
+        throw error;
+    }
+};
+
+/**
+ * Start watching the config file for external changes
+ */
+const startBridgesWatcher = (): void => {
+    // Ensure directory exists before watching
+    const dir = dirname(BRIDGES_PATH);
+    if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+    }
+
+    // Debounce timeout
+    let debounceTimer: NodeJS.Timeout | null = null;
+
+    try {
+        watch(dir, (eventType, filename) => {
+            if (filename === '.bridges.json' && eventType === 'change') {
+                // Debounce rapid changes
+                if (debounceTimer) {
+                    clearTimeout(debounceTimer);
+                }
+
+                debounceTimer = setTimeout(() => {
+                    try {
+                        if (existsSync(BRIDGES_PATH)) {
+                            const fileContent = readFileSync(BRIDGES_PATH, 'utf-8');
+                            const newBridges = JSON.parse(fileContent);
+
+                            // Only update if actually changed
+                            if (JSON.stringify(newBridges) !== JSON.stringify(currentBridges)) {
+                                currentBridges = newBridges;
+                                log.info('Bridges config file changed, reloading', {
+                                    count: currentBridges.length,
+                                });
+                                notifyListeners();
+                            }
+                        }
+                    } catch (error) {
+                        log.error('Error reloading bridges config', { error: (error as Error).message });
+                    }
+                }, 100);
+            }
+        });
+
+        log.info('Started watching bridges config file for changes', { path: BRIDGES_PATH });
+    } catch (error) {
+        log.warning('Failed to start bridges config file watcher', { error: (error as Error).message });
+    }
+};
 
 /**
  * Initialize bridges from input and start file watching
@@ -52,33 +143,6 @@ export const initializeBridges = (initialBridges?: Bridge[]): void => {
 
     // Start watching config file for changes
     startBridgesWatcher();
-};
-
-/**
- * Save bridges to config file
- * @param bridges - Bridges to save
- */
-export const saveBridges = (bridges: Bridge[]): void => {
-    try {
-        // Ensure directory exists
-        const dir = dirname(BRIDGES_PATH);
-        if (!existsSync(dir)) {
-            mkdirSync(dir, { recursive: true });
-        }
-
-        writeFileSync(BRIDGES_PATH, JSON.stringify(bridges, null, 2));
-        currentBridges = bridges;
-        log.info('Saved bridges to config file', {
-            count: bridges.length,
-            path: BRIDGES_PATH,
-        });
-
-        // Notify listeners
-        notifyListeners();
-    } catch (error) {
-        log.error('Failed to save bridges', { error: (error as Error).message });
-        throw error;
-    }
 };
 
 /**
@@ -138,66 +202,4 @@ export const removeBridge = (path: string): boolean => {
  */
 export const onBridgesChange = (callback: (bridges: Bridge[]) => void): void => {
     changeListeners.push(callback);
-};
-
-/**
- * Notify all listeners of bridge changes
- */
-const notifyListeners = (): void => {
-    for (const listener of changeListeners) {
-        try {
-            listener([...currentBridges]);
-        } catch (error) {
-            log.error('Error in bridges change listener', { error: (error as Error).message });
-        }
-    }
-};
-
-/**
- * Start watching the config file for external changes
- */
-const startBridgesWatcher = (): void => {
-    // Ensure directory exists before watching
-    const dir = dirname(BRIDGES_PATH);
-    if (!existsSync(dir)) {
-        mkdirSync(dir, { recursive: true });
-    }
-
-    // Debounce timeout
-    let debounceTimer: NodeJS.Timeout | null = null;
-
-    try {
-        watch(dir, (eventType, filename) => {
-            if (filename === '.bridges.json' && eventType === 'change') {
-                // Debounce rapid changes
-                if (debounceTimer) {
-                    clearTimeout(debounceTimer);
-                }
-
-                debounceTimer = setTimeout(() => {
-                    try {
-                        if (existsSync(BRIDGES_PATH)) {
-                            const fileContent = readFileSync(BRIDGES_PATH, 'utf-8');
-                            const newBridges = JSON.parse(fileContent);
-
-                            // Only update if actually changed
-                            if (JSON.stringify(newBridges) !== JSON.stringify(currentBridges)) {
-                                currentBridges = newBridges;
-                                log.info('Bridges config file changed, reloading', {
-                                    count: currentBridges.length,
-                                });
-                                notifyListeners();
-                            }
-                        }
-                    } catch (error) {
-                        log.error('Error reloading bridges config', { error: (error as Error).message });
-                    }
-                }, 100);
-            }
-        });
-
-        log.info('Started watching bridges config file for changes', { path: BRIDGES_PATH });
-    } catch (error) {
-        log.warning('Failed to start bridges config file watcher', { error: (error as Error).message });
-    }
 };

--- a/sandbox/src/environment.ts
+++ b/sandbox/src/environment.ts
@@ -10,21 +10,15 @@ import {
     INIT_SCRIPT_HEARTBEAT_INTERVAL_MS,
     INIT_SCRIPT_TIMEOUT_MS,
     JS_TS_CODE_DIR,
+    NODE_MODULES_DIR,
+    PYTHON_BIN_DIR,
     PYTHON_CODE_DIR,
+    PYTHON_VENV_DIR,
     SANDBOX_DIR,
 } from './consts.js';
 import { setStatusMessage } from './status.js';
 
 const execAsync = promisify(exec);
-
-/**
- * Directories for code execution environments
- */
-export const EXECUTION_DIRS = {
-    NODE_MODULES: path.join(JS_TS_CODE_DIR, 'node_modules'),
-    PYTHON_VENV: path.join(PYTHON_CODE_DIR, 'venv'),
-    PYTHON_BIN: path.join(PYTHON_CODE_DIR, 'venv', 'bin'),
-} as const;
 
 /**
  * Initialize code execution directories
@@ -58,7 +52,7 @@ export const initializeNodeEnvironment = async (): Promise<void> => {
     try {
         // Check if environment is already set up (from Dockerfile)
         const packageJsonPath = path.join(JS_TS_CODE_DIR, 'package.json');
-        const nodeModulesPath = EXECUTION_DIRS.NODE_MODULES;
+        const nodeModulesPath = NODE_MODULES_DIR;
 
         try {
             await fs.stat(packageJsonPath);
@@ -77,8 +71,8 @@ export const initializeNodeEnvironment = async (): Promise<void> => {
         await initializeCodeDirectories();
 
         // Create node_modules directory inside js-ts
-        await fs.mkdir(EXECUTION_DIRS.NODE_MODULES, { recursive: true, mode: 0o755 });
-        log.debug('Node modules directory created', { path: EXECUTION_DIRS.NODE_MODULES });
+        await fs.mkdir(NODE_MODULES_DIR, { recursive: true, mode: 0o755 });
+        log.debug('Node modules directory created', { path: NODE_MODULES_DIR });
 
         // Create package.json
         const packageJson = {
@@ -107,10 +101,10 @@ export const initializePythonEnvironment = async (): Promise<void> => {
     try {
         // Check if venv already exists (pre-installed from Dockerfile)
         try {
-            await fs.stat(EXECUTION_DIRS.PYTHON_VENV);
+            await fs.stat(PYTHON_VENV_DIR);
             await fs.stat(PYTHON_CODE_DIR);
             log.info('Python venv already set up (pre-installed from Dockerfile)', {
-                path: EXECUTION_DIRS.PYTHON_VENV,
+                path: PYTHON_VENV_DIR,
                 codeDir: PYTHON_CODE_DIR,
             });
             return;
@@ -123,25 +117,17 @@ export const initializePythonEnvironment = async (): Promise<void> => {
         await initializeCodeDirectories();
 
         // Create Python venv with clean environment to avoid conflicts
-        log.debug('Creating Python venv', { path: EXECUTION_DIRS.PYTHON_VENV });
+        log.debug('Creating Python venv', { path: PYTHON_VENV_DIR });
 
-        // Create a clean environment without PYTHONHOME/VIRTUAL_ENV to prevent conflicts
-        const cleanEnv: NodeJS.ProcessEnv = {};
-        Object.keys(process.env).forEach((key) => {
-            if (key !== 'PYTHONHOME' && key !== 'VIRTUAL_ENV') {
-                cleanEnv[key] = process.env[key];
-            }
-        });
-        // Explicitly set these to empty to override any inherited values
-        cleanEnv.PYTHONHOME = '';
-        cleanEnv.VIRTUAL_ENV = '';
+        // Blank out PYTHONHOME/VIRTUAL_ENV so inherited values can't conflict
+        const cleanEnv: NodeJS.ProcessEnv = { ...process.env, PYTHONHOME: '', VIRTUAL_ENV: '' };
 
-        await execAsync(`python3 -m venv ${EXECUTION_DIRS.PYTHON_VENV}`, {
+        await execAsync(`python3 -m venv ${PYTHON_VENV_DIR}`, {
             env: cleanEnv,
         });
 
         log.info('Python virtual environment initialized successfully', {
-            path: EXECUTION_DIRS.PYTHON_VENV,
+            path: PYTHON_VENV_DIR,
         });
     } catch (error) {
         const err = error as Error;
@@ -185,7 +171,7 @@ export const installNodeLibraries = async (
                 timeout: 120000, // 2 minutes per library
                 env: {
                     ...process.env,
-                    NODE_PATH: EXECUTION_DIRS.NODE_MODULES,
+                    NODE_PATH: NODE_MODULES_DIR,
                 },
             });
 
@@ -242,7 +228,7 @@ export const installPythonLibraries = async (
     // Ensure Python venv exists
     await initializePythonEnvironment();
 
-    const pipBinary = path.join(EXECUTION_DIRS.PYTHON_BIN, 'pip');
+    const pipBinary = path.join(PYTHON_BIN_DIR, 'pip');
 
     for (const requirement of requirements) {
         try {
@@ -406,29 +392,22 @@ export const getUserEnvVars = (): Record<string, string> => ({ ...userEnvVars })
  * Returns environment with paths to Python venv and Node modules
  */
 export const getExecutionEnvironment = (): NodeJS.ProcessEnv => {
-    const env: NodeJS.ProcessEnv = {};
-
-    // Copy all environment variables
-    Object.keys(process.env).forEach((key) => {
-        env[key] = process.env[key];
-    });
-
-    // Layer in user-supplied vars before our infra paths so the sandbox
-    // PATH/NODE_PATH/VIRTUAL_ENV/PYTHONHOME below always win.
-    Object.assign(env, userEnvVars);
+    // Layer user-supplied vars over the process env, before our infra paths so
+    // the sandbox PATH/NODE_PATH/VIRTUAL_ENV/PYTHONHOME below always win.
+    const env: NodeJS.ProcessEnv = { ...process.env, ...userEnvVars };
 
     // Add Python venv to PATH
     const currentPath = env.PATH || '';
-    env.PATH = `${EXECUTION_DIRS.PYTHON_BIN}:${currentPath}`;
+    env.PATH = `${PYTHON_BIN_DIR}:${currentPath}`;
 
     // Add Node modules to PATH
-    env.PATH = `${path.join(EXECUTION_DIRS.NODE_MODULES, '.bin')}:${env.PATH}`;
+    env.PATH = `${path.join(NODE_MODULES_DIR, '.bin')}:${env.PATH}`;
 
     // Set Node.js to find modules in js-ts/node_modules
-    env.NODE_PATH = EXECUTION_DIRS.NODE_MODULES;
+    env.NODE_PATH = NODE_MODULES_DIR;
 
     // Set Python to use the venv
-    env.VIRTUAL_ENV = EXECUTION_DIRS.PYTHON_VENV;
+    env.VIRTUAL_ENV = PYTHON_VENV_DIR;
     env.PYTHONHOME = '';
 
     return env;

--- a/sandbox/src/idle.ts
+++ b/sandbox/src/idle.ts
@@ -1,0 +1,58 @@
+/**
+ * Activity tracking and idle auto-shutdown.
+ *
+ * Every part of the server that counts as "someone is using the sandbox" —
+ * HTTP requests, shell WebSocket traffic, bridged requests — calls
+ * touchActivity(). Once the idle monitor is started, the Actor exits after
+ * the configured period with no activity (0 disables the shutdown entirely).
+ */
+import { Actor, log } from 'apify';
+
+import { DEFAULT_IDLE_TIMEOUT_SECS } from './consts.js';
+import { setStatusMessage } from './status.js';
+
+/** How often the idle monitor checks for inactivity. */
+const IDLE_CHECK_INTERVAL_MS = 30000;
+
+let lastActivityAt = Date.now();
+let idleTimeoutSecs = DEFAULT_IDLE_TIMEOUT_SECS;
+
+/** Record activity now, pushing back the idle-shutdown timer. */
+export const touchActivity = (): void => {
+    lastActivityAt = Date.now();
+};
+
+/** Set the idle timeout (seconds; 0 disables auto-shutdown). Call once at startup. */
+export const configureIdleTimeout = (secs: number | undefined): void => {
+    idleTimeoutSecs = secs ?? DEFAULT_IDLE_TIMEOUT_SECS;
+};
+
+/** The configured idle timeout in seconds (0 = disabled). */
+export const getIdleTimeoutSecs = (): number => idleTimeoutSecs;
+
+/** Seconds left until idle shutdown, or null when auto-shutdown is disabled. */
+export const getRemainingSecs = (): number | null => {
+    if (idleTimeoutSecs <= 0) return null;
+    const elapsedSecs = Math.floor((Date.now() - lastActivityAt) / 1000);
+    return Math.max(0, idleTimeoutSecs - elapsedSecs);
+};
+
+/**
+ * Start the periodic inactivity check that exits the Actor once the timeout
+ * elapses. No-op when the timeout is disabled.
+ */
+export const startIdleMonitor = (): void => {
+    if (idleTimeoutSecs <= 0) return;
+
+    log.info(`Idle timeout monitor started (${idleTimeoutSecs}s)`);
+    touchActivity();
+    setInterval(async () => {
+        const idleTimeMs = Date.now() - lastActivityAt;
+        if (idleTimeMs > idleTimeoutSecs * 1000) {
+            const message = `Sandbox shut down after ${Math.round(idleTimeoutSecs)} seconds of inactivity.`;
+            log.warning(message);
+            await setStatusMessage('Sandbox is shutting down');
+            await Actor.exit({ statusMessage: message });
+        }
+    }, IDLE_CHECK_INTERVAL_MS);
+};

--- a/sandbox/src/main.ts
+++ b/sandbox/src/main.ts
@@ -1,66 +1,49 @@
-import { spawn } from 'node:child_process';
-import { chmodSync, mkdirSync, writeFileSync } from 'node:fs';
-import http, { createServer } from 'node:http';
-import type { Duplex } from 'node:stream';
+/**
+ * Actor entrypoint: runs the startup sequence (input parsing, migration
+ * restore, dependency installation, init script), then assembles and starts
+ * the HTTP server.
+ *
+ * Feature logic lives in dedicated modules — routes/* for the HTTP API,
+ * shell-server.ts for the interactive terminal, bridge-proxy.ts for exposing
+ * local servers, idle.ts for the inactivity shutdown. This file is the
+ * sequence and the wiring, top to bottom.
+ */
+import { createServer } from 'node:http';
 
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { Actor, log } from 'apify';
 import type { Request, Response } from 'express';
 import express from 'express';
-import httpProxy from 'http-proxy';
 
-import { DEFAULT_IDLE_TIMEOUT_SECS, SANDBOX_DIR } from './consts.js';
+import { bridgeRequestHandler, handleBridgeUpgrade, initializeBridgeProxies } from './bridge-proxy.js';
+import { initializeBridges } from './bridges.js';
 import { parseEnvVars } from './env-vars.js';
 import { executeInitScript, setupExecutionEnvironment, setUserEnvVars } from './environment.js';
-import { createMcpServer } from './mcp.js';
+import { configureIdleTimeout, getIdleTimeoutSecs, getRemainingSecs, startIdleMonitor, touchActivity } from './idle.js';
 import { configureAgentMcpServers } from './mcp-agent-config.js';
 import { writeMcpConfig } from './mcp-connections.js';
-import { translateLaunchParam } from './shell-launch.js';
 import { parseNodeDependencies } from './node-deps.js';
-import { setStatusMessage } from './status.js';
-import {
-    appendFile,
-    createDirectory,
-    createZipArchive,
-    deleteFileOrDirectory,
-    executeCode,
-    listFilesDetailed,
-    readFileBinary,
-    runCommand,
-    statPath,
-    writeFileBinary,
-} from './operations.js';
 import { initializePersistence, restoreMigrationState, saveMigrationState } from './persistence.js';
-import {
-    addBridge,
-    getBridges,
-    initializeBridges,
-    onBridgesChange,
-    removeBridge,
-    saveBridges,
-} from './bridges.js';
+import { createBridgesRouter } from './routes/bridges.js';
+import { handleExec } from './routes/exec.js';
+import { createFsRouter } from './routes/fs.js';
+import { handleMcp } from './routes/mcp.js';
+import { handleShellUpgrade, registerShellRoutes, startShellBackend } from './shell-server.js';
 import { parseSkills } from './skills.js';
+import { setStatusMessage } from './status.js';
 import { getBrowsePageHTML } from './templates/browse.js';
 import { getLandingPageHTML, getLLMsMarkdown } from './templates/landing.js';
-import { injectTerminalReconnectScript, SANDBOX_BASHRC, WELCOME_SCRIPT } from './templates/shell.js';
-import {
-    appendTtydOutput,
-    buildShellUnavailableMessage,
-    isTtydStartupCrash,
-    nextTtydRestartDelayMs,
-    TTYD_RESTART_MIN_MS,
-} from './ttyd.js';
-import type { ActorInput, Bridge } from './types.js';
+import type { ActorInput } from './types.js';
 
-// Track initialization state
+// ============================================================================
+// Startup sequence
+// ============================================================================
+
+// Track initialization state for the /health endpoint
 let initializationComplete = false;
 let initializationError: string | null = null;
-let lastActivityAt = Date.now();
-// Seconds of inactivity before auto-shutdown (0 = disabled). Set from input at
-// startup; kept module-level so the landing page and /health can report it.
-let idleTimeoutSecs = DEFAULT_IDLE_TIMEOUT_SECS;
 
-// Check if running in local mode
+// In local mode (MODE=local) the sandbox directories, dependency installation,
+// init script, and ttyd are all skipped — only the HTTP server runs.
 const isLocalMode = process.env.MODE === 'local';
 if (isLocalMode) {
     log.info('🔧 Running in LOCAL MODE - Sandbox directories and environment setup will be skipped');
@@ -77,6 +60,7 @@ const serverUrl = process.env.ACTOR_WEB_SERVER_URL || `http://localhost:${port}`
 
 // Retrieve Actor input
 const input = await Actor.getInput<ActorInput>();
+configureIdleTimeout(input?.idleTimeoutSecs);
 
 // Parse and register user-supplied environment variables. Apify decrypts the
 // secret input at runtime; we never log values, only key names.
@@ -117,36 +101,28 @@ if (!isLocalMode) {
 }
 
 // Setup execution environment with dependencies (skip if restored from migration)
-let setupResult;
 if (restoredFromMigration) {
     log.info('Skipping dependency installation (already restored from migration)');
-    setupResult = {
-        success: true,
-        skillsSetup: { installed: [], failed: [] },
-        nodeSetup: { installed: [], failed: [] },
-        pythonSetup: { installed: [], failed: [] },
-        errors: [],
-    };
 } else {
     log.info('Setting up execution environment...');
-    setupResult = await setupExecutionEnvironment({
+    const setupResult = await setupExecutionEnvironment({
         skills,
         nodeDependencies,
         pythonRequirements: input?.pythonRequirements,
     });
-}
 
-if (!setupResult.success) {
-    log.warning('Some dependencies failed to install', {
-        skillsInstalled: setupResult.skillsSetup.installed,
-        skillsFailed: setupResult.skillsSetup.failed,
-        nodeInstalled: setupResult.nodeSetup.installed,
-        nodeFailed: setupResult.nodeSetup.failed,
-        pythonInstalled: setupResult.pythonSetup.installed,
-        pythonFailed: setupResult.pythonSetup.failed,
-    });
-} else {
-    log.info('All dependencies and skills installed successfully');
+    if (!setupResult.success) {
+        log.warning('Some dependencies failed to install', {
+            skillsInstalled: setupResult.skillsSetup.installed,
+            skillsFailed: setupResult.skillsSetup.failed,
+            nodeInstalled: setupResult.nodeSetup.installed,
+            nodeFailed: setupResult.nodeSetup.failed,
+            pythonInstalled: setupResult.pythonSetup.installed,
+            pythonFailed: setupResult.pythonSetup.failed,
+        });
+    } else {
+        log.info('All dependencies and skills installed successfully');
+    }
 }
 
 // Execute init script if provided and not empty
@@ -170,20 +146,6 @@ for (const key of Object.keys(userEnvVars)) {
     delete userEnvVars[key];
 }
 setUserEnvVars({});
-
-// Setup shell environment files
-if (!isLocalMode) {
-    try {
-        log.info('Writing shell environment files...');
-        mkdirSync('/app', { recursive: true });
-        writeFileSync('/app/welcome.sh', WELCOME_SCRIPT);
-        chmodSync('/app/welcome.sh', 0o755);
-        writeFileSync('/app/sandbox_bashrc', SANDBOX_BASHRC);
-        log.info('Shell environment files written successfully');
-    } catch (err) {
-        log.error('Failed to write shell environment files', { error: (err as Error).message });
-    }
-}
 
 // Initialize persistence system (create startup marker for tracking changes)
 // Only needed on fresh starts — after migration restore, the marker is already
@@ -212,456 +174,49 @@ if (!isLocalMode) {
 
 // Mark initialization as complete
 initializationComplete = true;
-lastActivityAt = Date.now();
+touchActivity();
 log.info('Actor startup complete - ready for requests');
 await setStatusMessage('Sandbox is live');
 
-// Initialize bridges
+// Load the bridge configuration (Actor input or persisted file) and start
+// watching it for changes.
 initializeBridges(input?.bridges);
 
-// Create Express app
-const app = express();
+// ============================================================================
+// HTTP server assembly
+// ============================================================================
 
-// Activity tracking middleware
+const app = express();
+// HTTP server wrapper is needed to handle WebSocket upgrades (shell, bridges)
+const server = createServer(app);
+
+// Any non-health request — including doc fetches like /llms.txt — counts as
+// activity and pushes back the idle-shutdown timer. Only /health and the
+// readiness probe are excluded, since they fire automatically.
 app.use((req, _res, next) => {
     const isHealth = req.path === '/health';
     const isProbe = !!req.headers['x-apify-container-server-readiness-probe'];
-
-    // Debug: Log all incoming paths that start with /openclaw
-    if (req.path.startsWith('/openclaw')) {
-        log.info('DEBUG incoming request', {
-            path: req.path,
-            url: req.url,
-            originalUrl: req.originalUrl,
-        });
-    }
-
-    // Any non-health request — including doc fetches like /llms.txt — counts as
-    // activity and pushes back the idle-shutdown timer. Only /health and the
-    // readiness probe are excluded, since they fire automatically.
     if (!isHealth && !isProbe) {
-        lastActivityAt = Date.now();
+        touchActivity();
     }
     next();
 });
 
-// Create HTTP server for WebSocket support
-const server = createServer(app);
-
-// ============================================================================
-// Helper Functions
-// ============================================================================
-
-/**
- * Normalize language aliases to canonical form
- * @param lang - Language string (optional)
- * @returns Normalized language or null if invalid/not provided
- */
-const normalizeLanguage = (lang?: string): 'js' | 'ts' | 'py' | 'shell' | null => {
-    if (!lang) return null;
-    const lower = lang.toLowerCase();
-    const mapping: Record<string, 'js' | 'ts' | 'py' | 'shell'> = {
-        js: 'js',
-        javascript: 'js',
-        ts: 'ts',
-        typescript: 'ts',
-        py: 'py',
-        python: 'py',
-        bash: 'shell',
-        sh: 'shell',
-    };
-    return mapping[lower] || null;
-};
-
-// ============================================================================
-// RESTful Filesystem Endpoints (/fs/*)
-// IMPORTANT: These MUST come before app.use(express.json()) to handle raw bodies
-// ============================================================================
-
-// HEAD /fs and /fs/ - Root directory metadata (must come before wildcard route)
-const handleHeadRoot = async (_req: Request, res: Response) => {
-    try {
-        const filePath = ''; // Empty string resolves to /sandbox
-        log.info('REST HEAD /fs (root) request received', { path: filePath });
-
-        const result = await statPath(filePath);
-
-        if (!result.exists || result.error) {
-            log.warning('REST HEAD /fs (root) failed', { path: filePath, error: result.error });
-            res.status(404).end();
-            return;
-        }
-
-        // Set metadata headers
-        res.setHeader('X-File-Type', result.type);
-        res.setHeader('X-Path', result.path);
-
-        if (result.mtime) {
-            res.setHeader('Last-Modified', result.mtime.toUTCString());
-        }
-
-        log.info('REST HEAD /fs (root) completed successfully', { path: result.path, type: result.type });
-        res.status(200).end();
-    } catch (error) {
-        log.error('REST HEAD /fs (root) error', { error });
-        res.status(500).end();
-    }
-};
-
-app.head('/fs', handleHeadRoot);
-app.head('/fs/', handleHeadRoot);
-
-// GET /fs and /fs/ - List root directory (must come before wildcard route)
-const handleGetRoot = async (req: Request, res: Response) => {
-    try {
-        const filePath = ''; // Empty string resolves to /sandbox
-        const download = req.query.download === '1';
-
-        log.info('REST GET /fs (root) request received', { path: filePath, download });
-
-        // Check if path exists and get type
-        const statResult = await statPath(filePath);
-
-        if (!statResult.exists || statResult.error) {
-            log.warning('REST GET /fs (root) failed', { path: filePath, error: statResult.error });
-            res.status(404).json({ error: statResult.error || 'Path not found', path: filePath });
-            return;
-        }
-
-        if (statResult.type === 'directory') {
-            // Directory: either return JSON listing or ZIP download
-            if (download) {
-                // Download directory as ZIP
-                const zipResult = await createZipArchive(filePath);
-
-                if (zipResult.error || !zipResult.stream) {
-                    log.warning('REST GET /fs (root) ZIP creation failed', { path: filePath, error: zipResult.error });
-                    res.status(500).json({ error: zipResult.error || 'Failed to create ZIP archive' });
-                    return;
-                }
-
-                // Extract directory name for filename
-                res.setHeader('Content-Type', 'application/zip');
-                res.setHeader('Content-Disposition', 'attachment; filename="sandbox.zip"');
-
-                log.info('REST GET /fs (root) streaming ZIP', { path: zipResult.path });
-                zipResult.stream.pipe(res);
-            } else {
-                // Return JSON directory listing
-                const listResult = await listFilesDetailed(filePath);
-
-                if (listResult.error) {
-                    log.warning('REST GET /fs (root) directory listing failed', {
-                        path: filePath,
-                        error: listResult.error,
-                    });
-                    res.status(500).json({ error: listResult.error, path: filePath });
-                    return;
-                }
-
-                log.info('REST GET /fs (root) directory listing completed', {
-                    path: listResult.path,
-                    entryCount: listResult.entries.length,
-                });
-                res.json(listResult);
-            }
-        }
-    } catch (error) {
-        log.error('REST GET /fs (root) error', { error });
-        const err = error as Error;
-        res.status(500).json({ error: err.message });
-    }
-};
-
-app.get('/fs', handleGetRoot);
-app.get('/fs/', handleGetRoot);
-
-// HEAD /fs/* - Get file or directory metadata
-app.head('/fs/*path', async (req: Request, res: Response) => {
-    try {
-        const filePath = String(req.params.path || '/');
-
-        log.info('REST HEAD /fs/* request received', { path: filePath });
-
-        const result = await statPath(filePath);
-
-        if (!result.exists || result.error) {
-            log.warning('REST HEAD /fs/* failed', { path: filePath, error: result.error });
-            res.status(404).end();
-            return;
-        }
-
-        // Set metadata headers
-        res.setHeader('X-File-Type', result.type);
-        res.setHeader('X-Path', result.path);
-
-        if (result.mtime) {
-            res.setHeader('Last-Modified', result.mtime.toUTCString());
-        }
-
-        if (result.type === 'file' && result.size !== undefined) {
-            res.setHeader('Content-Length', result.size.toString());
-            // Detect MIME type from file extension
-            const mimeResult = await readFileBinary(filePath);
-            if (mimeResult.mimeType) {
-                res.setHeader('Content-Type', mimeResult.mimeType);
-            }
-        }
-
-        log.info('REST HEAD /fs/* completed successfully', { path: result.path, type: result.type });
-        res.status(200).end();
-    } catch (error) {
-        log.error('REST HEAD /fs/* error', { error });
-        res.status(500).end();
-    }
-});
-
-// GET /fs/* - Read file or list directory
-app.get('/fs/*path', async (req: Request, res: Response) => {
-    try {
-        const filePath = String(req.params.path || '/');
-        const download = req.query.download === '1';
-
-        log.info('REST GET /fs/* request received', { path: filePath, download });
-
-        // Check if path exists and get type
-        const statResult = await statPath(filePath);
-
-        if (!statResult.exists || statResult.error) {
-            log.warning('REST GET /fs/* failed', { path: filePath, error: statResult.error });
-            res.status(404).json({ error: statResult.error || 'Path not found', path: filePath });
-            return;
-        }
-
-        if (statResult.type === 'directory') {
-            // Directory: either return JSON listing or ZIP download
-            if (download) {
-                // Download directory as ZIP
-                const zipResult = await createZipArchive(filePath);
-
-                if (zipResult.error || !zipResult.stream) {
-                    log.warning('REST GET /fs/* ZIP creation failed', { path: filePath, error: zipResult.error });
-                    res.status(500).json({ error: zipResult.error || 'Failed to create ZIP archive' });
-                    return;
-                }
-
-                // Extract directory name for filename
-                const dirName = filePath.split('/').filter(Boolean).pop() || 'archive';
-                res.setHeader('Content-Type', 'application/zip');
-                res.setHeader('Content-Disposition', `attachment; filename="${dirName}.zip"`);
-
-                log.info('REST GET /fs/* streaming ZIP', { path: zipResult.path });
-                zipResult.stream.pipe(res);
-            } else {
-                // Return JSON directory listing
-                const listResult = await listFilesDetailed(filePath);
-
-                if (listResult.error) {
-                    log.warning('REST GET /fs/* directory listing failed', { path: filePath, error: listResult.error });
-                    res.status(500).json({ error: listResult.error, path: filePath });
-                    return;
-                }
-
-                log.info('REST GET /fs/* directory listing completed', {
-                    path: listResult.path,
-                    entryCount: listResult.entries.length,
-                });
-                res.json(listResult);
-            }
-        } else {
-            // File: return raw bytes with appropriate Content-Type
-            const fileResult = await readFileBinary(filePath);
-
-            if (fileResult.error || !fileResult.content) {
-                log.warning('REST GET /fs/* file read failed', { path: filePath, error: fileResult.error });
-                res.status(404).json({ error: fileResult.error || 'Failed to read file', path: filePath });
-                return;
-            }
-
-            // Set Content-Type
-            res.setHeader('Content-Type', fileResult.mimeType || 'application/octet-stream');
-
-            // Set Content-Disposition for download
-            if (download) {
-                const fileName = filePath.split('/').filter(Boolean).pop() || 'file';
-                res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
-            }
-
-            log.info('REST GET /fs/* file read completed', {
-                path: fileResult.path,
-                size: fileResult.size,
-                mimeType: fileResult.mimeType,
-            });
-            res.send(fileResult.content);
-        }
-    } catch (error) {
-        log.error('REST GET /fs/* error', { error });
-        const err = error as Error;
-        res.status(500).json({ error: err.message });
-    }
-});
-
-// PUT /fs/* - Write/replace file
-app.put('/fs/*path', express.raw({ type: '*/*', limit: '500mb' }), async (req: Request, res: Response) => {
-    try {
-        const filePath = String(req.params.path || '');
-        const content = req.body;
-
-        log.info('REST PUT /fs/* request received', {
-            path: filePath,
-            contentLength: content?.length,
-            contentType: req.headers['content-type'],
-        });
-
-        if (!filePath || filePath === '/') {
-            log.warning('REST PUT /fs/*: cannot write to root directory');
-            res.status(400).json({ error: 'Cannot write to root directory' });
-            return;
-        }
-
-        if (!content) {
-            log.warning('REST PUT /fs/*: content is required');
-            res.status(400).json({ error: 'Content is required' });
-            return;
-        }
-
-        const result = await writeFileBinary(filePath, content);
-
-        if (!result.success) {
-            log.warning('REST PUT /fs/* failed', { path: filePath, error: result.error });
-            res.status(500).json({ error: result.error, path: filePath });
-            return;
-        }
-
-        log.info('REST PUT /fs/* completed successfully', { path: result.path, size: result.size });
-        res.status(200).json({ success: true, path: result.path, size: result.size });
-    } catch (error) {
-        log.error('REST PUT /fs/* error', { error });
-        const err = error as Error;
-        res.status(500).json({ error: err.message });
-    }
-});
-
-// POST /fs/* - Create directory or append to file
-app.post('/fs/*path', express.raw({ type: '*/*', limit: '500mb' }), async (req: Request, res: Response) => {
-    try {
-        const filePath = String(req.params.path || '');
-        const mkdir = req.query.mkdir === '1';
-        const append = req.query.append === '1';
-
-        log.info('REST POST /fs/* request received', { path: filePath, mkdir, append });
-
-        if (!filePath || filePath === '/') {
-            log.warning('REST POST /fs/*: cannot operate on root directory');
-            res.status(400).json({ error: 'Cannot operate on root directory' });
-            return;
-        }
-
-        if (!mkdir && !append) {
-            log.warning('REST POST /fs/*: either mkdir=1 or append=1 query parameter is required');
-            res.status(400).json({ error: 'Either mkdir=1 or append=1 query parameter is required' });
-            return;
-        }
-
-        if (mkdir && append) {
-            log.warning('REST POST /fs/*: cannot use both mkdir and append');
-            res.status(400).json({ error: 'Cannot use both mkdir=1 and append=1' });
-            return;
-        }
-
-        if (mkdir) {
-            // Create directory
-            const result = await createDirectory(filePath);
-
-            if (!result.success) {
-                log.warning('REST POST /fs/* mkdir failed', { path: filePath, error: result.error });
-                res.status(500).json({ error: result.error, path: filePath });
-                return;
-            }
-
-            log.info('REST POST /fs/* mkdir completed successfully', { path: result.path });
-            res.status(201).json({ success: true, path: result.path, type: 'directory' });
-        } else {
-            // Append to file
-            const content = req.body;
-
-            if (!content) {
-                log.warning('REST POST /fs/* append: content is required');
-                res.status(400).json({ error: 'Content is required for append operation' });
-                return;
-            }
-
-            const result = await appendFile(filePath, content);
-
-            if (!result.success) {
-                log.warning('REST POST /fs/* append failed', { path: filePath, error: result.error });
-                res.status(500).json({ error: result.error, path: filePath });
-                return;
-            }
-
-            log.info('REST POST /fs/* append completed successfully', { path: result.path, size: result.size });
-            res.status(200).json({ success: true, path: result.path, size: result.size });
-        }
-    } catch (error) {
-        log.error('REST POST /fs/* error', { error });
-        const err = error as Error;
-        res.status(500).json({ error: err.message });
-    }
-});
-
-// DELETE /fs/* - Delete file or directory
-app.delete('/fs/*path', async (req: Request, res: Response) => {
-    try {
-        const filePath = String(req.params.path || '');
-        const recursive = req.query.recursive === '1';
-
-        log.info('REST DELETE /fs/* request received', { path: filePath, recursive });
-
-        if (!filePath || filePath === '/') {
-            log.warning('REST DELETE /fs/*: cannot delete root directory');
-            res.status(400).json({ error: 'Cannot delete root directory' });
-            return;
-        }
-
-        const result = await deleteFileOrDirectory(filePath, recursive);
-
-        if (!result.success) {
-            // Check if error is due to non-empty directory
-            if (result.error?.includes('not empty')) {
-                log.warning('REST DELETE /fs/* failed - directory not empty', { path: filePath, error: result.error });
-                res.status(409).json({ error: result.error, path: filePath, code: 'DIRECTORY_NOT_EMPTY' });
-                return;
-            }
-
-            log.warning('REST DELETE /fs/* failed', { path: filePath, error: result.error });
-            res.status(500).json({ error: result.error, path: filePath });
-            return;
-        }
-
-        log.info('REST DELETE /fs/* completed successfully', { path: result.path });
-        res.status(200).json({ success: true, path: result.path, deleted: true });
-    } catch (error) {
-        log.error('REST DELETE /fs/* error', { error });
-        const err = error as Error;
-        res.status(500).json({ error: err.message });
-    }
-});
-
-// ============================================================================
-// JSON-based REST Endpoints (require express.json middleware)
-// ============================================================================
+// RESTful filesystem API. MUST be mounted before express.json() so PUT/POST
+// bodies stay raw (the JSON parser would consume them).
+app.use('/fs', createFsRouter());
 
 // Middleware for JSON parsing (applied to routes below)
 app.use(express.json({ limit: '50mb' }));
 
-// Landing page endpoint
+// Landing page
 app.get('/', (_req: Request, res: Response) => {
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
     res.send(
         getLandingPageHTML({
             serverUrl,
             isLocalMode,
-            idleTimeoutSecs,
+            idleTimeoutSecs: getIdleTimeoutSecs(),
         }),
     );
 });
@@ -679,95 +234,11 @@ app.get('/browse/*path', handleBrowse);
 // LLMs.txt endpoint (Markdown documentation for LLMs)
 app.get('/llms.txt', (_req: Request, res: Response) => {
     res.setHeader('Content-Type', 'text/plain; charset=utf-8');
-    res.send(getLLMsMarkdown({ serverUrl, idleTimeoutSecs }));
+    res.send(getLLMsMarkdown({ serverUrl, idleTimeoutSecs: getIdleTimeoutSecs() }));
 });
 
-// ============================================================================
-// Bridges configuration endpoints
-// ============================================================================
-
-// GET /bridges - Get current bridges
-app.get('/bridges', (_req: Request, res: Response) => {
-    try {
-        const bridges = getBridges();
-        res.json({ bridges });
-    } catch (error) {
-        log.error('Failed to get bridges', { error: (error as Error).message });
-        res.status(500).json({ error: (error as Error).message });
-    }
-});
-
-// PUT /bridges - Replace all bridges
-app.put('/bridges', (req: Request, res: Response) => {
-    try {
-        const { bridges } = req.body;
-
-        if (!Array.isArray(bridges)) {
-            res.status(400).json({ error: 'bridges must be an array' });
-            return;
-        }
-
-        // Validate each bridge
-        for (const bridge of bridges) {
-            if (!bridge.path || typeof bridge.path !== 'string') {
-                res.status(400).json({ error: 'Each bridge must have a path string' });
-                return;
-            }
-            if (!bridge.target || typeof bridge.target !== 'string') {
-                res.status(400).json({ error: 'Each bridge must have a target string (full URL like http://127.0.0.1:3000/myapp)' });
-                return;
-            }
-        }
-
-        saveBridges(bridges);
-        log.info('Bridges updated via API', { count: bridges.length });
-        res.json({ success: true, bridges: getBridges() });
-    } catch (error) {
-        log.error('Failed to update bridges', { error: (error as Error).message });
-        res.status(500).json({ error: (error as Error).message });
-    }
-});
-
-// POST /bridges - Add a single bridge
-app.post('/bridges', (req: Request, res: Response) => {
-    try {
-        const { path, target } = req.body;
-
-        if (!path || typeof path !== 'string') {
-            res.status(400).json({ error: 'path is required (e.g., /myapp)' });
-            return;
-        }
-        if (!target || typeof target !== 'string') {
-            res.status(400).json({ error: 'target is required (full URL like http://127.0.0.1:3000/myapp)' });
-            return;
-        }
-
-        addBridge({ path, target });
-        log.info('Bridge added via API', { path, target });
-        res.json({ success: true, bridges: getBridges() });
-    } catch (error) {
-        log.error('Failed to add bridge', { error: (error as Error).message });
-        res.status(500).json({ error: (error as Error).message });
-    }
-});
-
-// DELETE /bridges/:path - Remove a bridge
-app.delete('/bridges/*path', (req: Request, res: Response) => {
-    try {
-        const pathToRemove = `/${  String(req.params.path || '')}`;
-
-        const removed = removeBridge(pathToRemove);
-        if (removed) {
-            log.info('Bridge removed via API', { path: pathToRemove });
-            res.json({ success: true, removed: pathToRemove, bridges: getBridges() });
-        } else {
-            res.status(404).json({ error: 'Bridge not found', path: pathToRemove });
-        }
-    } catch (error) {
-        log.error('Failed to remove bridge', { error: (error as Error).message });
-        res.status(500).json({ error: (error as Error).message });
-    }
-});
+// Bridges configuration API
+app.use('/bridges', createBridgesRouter());
 
 // Health check endpoint
 app.get('/health', (_req: Request, res: Response) => {
@@ -787,536 +258,43 @@ app.get('/health', (_req: Request, res: Response) => {
         return;
     }
 
-    const body: Record<string, unknown> = { status: 'healthy', idleTimeoutSecs };
-    if (idleTimeoutSecs > 0) {
-        const elapsedSecs = Math.floor((Date.now() - lastActivityAt) / 1000);
-        body.remainingSecs = Math.max(0, idleTimeoutSecs - elapsedSecs);
+    const body: Record<string, unknown> = { status: 'healthy', idleTimeoutSecs: getIdleTimeoutSecs() };
+    const remainingSecs = getRemainingSecs();
+    if (remainingSecs !== null) {
+        body.remainingSecs = remainingSecs;
     }
     res.json(body);
 });
 
-// MCP endpoint using proper StreamableHTTPServerTransport
-app.post('/mcp', async (req: Request, res: Response) => {
-    log.info('MCP request received', { body: req.body });
-    const mcpServer = createMcpServer();
-    try {
-        const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport({
-            sessionIdGenerator: undefined,
-        });
-        await mcpServer.connect(transport);
-        await transport.handleRequest(req, res, req.body);
-        res.on('close', () => {
-            log.info('MCP request closed');
-            void transport.close();
-            void mcpServer.close();
-        });
-    } catch (error) {
-        log.error('MCP request error', { error });
-        if (!res.headersSent) {
-            res.status(500).json({
-                jsonrpc: '2.0',
-                error: {
-                    code: -32603,
-                    message: 'Internal server error',
-                },
-                id: null,
-            });
-        }
-    }
-});
+// MCP endpoint (Streamable HTTP transport)
+app.post('/mcp', handleMcp);
 
 // Execute shell command or code (unified endpoint)
-app.post('/exec', async (req: Request, res: Response) => {
-    try {
-        const { command, language, cwd, timeoutSecs } = req.body;
+app.post('/exec', handleExec);
 
-        log.info('REST /exec request received', { command: command?.substring(0, 100), language, cwd, timeoutSecs });
-
-        // Validate command is required
-        if (!command) {
-            log.debug('REST /exec: command is required');
-            res.status(400).json({
-                error: 'Command is required',
-            });
-            return;
-        }
-
-        // Normalize language aliases
-        const normalizedLang = normalizeLanguage(language);
-
-        // Validate language if provided
-        if (language && !normalizedLang) {
-            log.debug('REST /exec: invalid language', { language });
-            res.status(400).json({
-                error: `Invalid language: ${language}. Supported: js, javascript, ts, typescript, py, python, bash, sh`,
-            });
-            return;
-        }
-
-        // Convert timeout from seconds to milliseconds
-        const timeoutMs = timeoutSecs ? timeoutSecs * 1000 : undefined;
-
-        let result;
-
-        // Route to appropriate executor based on language
-        if (!normalizedLang || normalizedLang === 'shell') {
-            // Shell command execution
-            log.debug('REST /exec: executing shell command', { cwd, timeoutMs });
-            result = await runCommand(command, cwd, timeoutMs);
-            result = { ...result, language: 'shell' };
-        } else {
-            // Code execution (js, ts, py)
-            log.debug('REST /exec: executing code', { language: normalizedLang, cwd, timeoutMs });
-            result = await executeCode(command, normalizedLang, timeoutMs, cwd);
-        }
-
-        // Return appropriate status code
-        if (result.exitCode !== 0) {
-            log.debug('REST /exec completed with error', { language: result.language, exitCode: result.exitCode });
-            res.status(500).json(result);
-            return;
-        }
-
-        log.info('REST /exec completed successfully', { language: result.language });
-        res.json(result);
-    } catch (error) {
-        log.error('REST /exec error', { error });
-        const err = error as Error;
-        res.status(500).json({
-            error: err.message,
-            stdout: '',
-            stderr: '',
-            exitCode: 1,
-            language: 'shell',
-        });
-    }
-});
-
-// ============================================================================
-// Shell (ttyd) Implementation
-// ============================================================================
-const shellPort = 7681;
-
-// ttyd's last words: the tail of its stdout/stderr (or a spawn error). Recorded
-// so a crash — e.g. a missing shared library — shows up in the Actor log and in
-// the /shell proxy response instead of a bare exit code. The delay grows as ttyd
-// keeps failing to start (see nextTtydRestartDelayMs).
-let lastTtydError = '';
-let ttydRestartDelayMs = TTYD_RESTART_MIN_MS;
-
-// Spawn ttyd process
-const spawnTtyd = () => {
-    log.info('Spawning ttyd process...', { port: shellPort });
-    const startedAt = Date.now();
-
-    // Run ttyd with custom bashrc for better UX and environment alignment. Pipe
-    // its stdio (rather than ignoring it) so a startup failure is captured.
-    const ttyd = spawn('ttyd', ['-p', shellPort.toString(), '-a', '-W', 'bash', '--rcfile', '/app/sandbox_bashrc'], {
-        stdio: ['ignore', 'pipe', 'pipe'],
-        cwd: SANDBOX_DIR,
-        env: { ...process.env },
-    });
-
-    // Keep only the tail of ttyd's output — its startup/error messages are short.
-    let recentOutput = '';
-    const capture = (chunk: Buffer): void => {
-        recentOutput = appendTtydOutput(recentOutput, chunk.toString());
-    };
-    ttyd.stdout?.on('data', capture);
-    ttyd.stderr?.on('data', capture);
-
-    // Schedule exactly one restart per spawn: a failed spawn emits 'error' (no
-    // 'exit'), a started process emits 'exit'; guard against both firing.
-    let settled = false;
-    const restartAfter = (crashed: boolean): void => {
-        if (settled) return;
-        settled = true;
-        const delay = crashed ? ttydRestartDelayMs : TTYD_RESTART_MIN_MS;
-        ttydRestartDelayMs = nextTtydRestartDelayMs(ttydRestartDelayMs, crashed);
-        setTimeout(spawnTtyd, delay);
-    };
-
-    ttyd.on('error', (err) => {
-        lastTtydError = err.message;
-        log.error('Failed to start ttyd', { error: err.message });
-        restartAfter(true);
-    });
-
-    ttyd.on('exit', (code, signal) => {
-        const aliveMs = Date.now() - startedAt;
-        const output = recentOutput.trim();
-        if (output) lastTtydError = output;
-
-        // A fast exit means ttyd never really came up (missing shared library,
-        // port already bound, bad args). Shout, since the old fixed-5s retry with
-        // no detail produced an invisible crash loop behind "Shell Proxy Error".
-        const crashed = isTtydStartupCrash(aliveMs);
-        if (crashed) {
-            log.error('ttyd exited immediately — interactive shell is unavailable', {
-                code,
-                signal,
-                aliveMs,
-                output: output || '(no output captured)',
-            });
-        } else {
-            log.warning('ttyd process exited; restarting', { code, signal, aliveMs });
-        }
-        restartAfter(crashed);
-    });
-};
-
+// Interactive shell: /shell HTTP traffic is proxied to ttyd; the ttyd process
+// itself only runs in production mode (the proxy then reports it unavailable).
+registerShellRoutes(app);
 if (!isLocalMode) {
-    spawnTtyd();
+    startShellBackend();
 }
 
-// ============================================================================
-// Terminal disconnect messaging
-// ============================================================================
-//
-// There is deliberately no server-side shutdown banner. Most stops (run timeout,
-// hard abort, platform scale-down) kill the container with a signal and no
-// advance event — the Apify SDK installs no SIGTERM/SIGINT handlers, it's driven
-// by the platform events WebSocket — and a dying process can't reliably flush a
-// message to the browser anyway. Instead the terminal page relabels ttyd's own
-// reconnect overlay client-side; see injectTerminalReconnectScript in
-// templates/shell.ts (it shows "Actor probably finished" when a retry fails).
+// Bridges: forward requests on exposed paths to local servers. Registered
+// last so explicit endpoints always win over bridged paths.
+initializeBridgeProxies();
+app.use(bridgeRequestHandler);
 
-// Manual HTTP Proxy for ttyd
-app.all('/shell{*rest}', (req, res) => {
-    let path = req.url.replace(/^\/shell/, '') || '/';
-    // Ensure path starts with / (handle query strings like ?arg=...)
-    if (path.startsWith('?')) {
-        path = `/${  path}`;
-    }
-    path = translateLaunchParam(path);
-    // Ask ttyd for an uncompressed response so the terminal HTML can be rewritten
-    // (see injectTerminalReconnectScript below). ttyd's assets are tiny, so losing
-    // gzip here is negligible.
-    const headers = { ...req.headers, 'accept-encoding': 'identity' };
-    const options = {
-        hostname: '127.0.0.1',
-        port: shellPort,
-        path,
-        method: req.method,
-        headers,
-    };
-
-    const proxyReq = http.request(options, (proxyRes) => {
-        // Inject the client-side reconnect notice into ttyd's terminal page. The
-        // server can't reliably push a shutdown message as the container is killed,
-        // so the browser relabels ttyd's reconnect overlay instead. Only the HTML
-        // document is rewritten; every other asset and status is piped through.
-        const isHtml = (proxyRes.headers['content-type'] || '').includes('text/html');
-        if (!isHtml) {
-            if (proxyRes.statusCode) {
-                res.writeHead(proxyRes.statusCode, proxyRes.headers);
-            }
-            proxyRes.pipe(res);
-            return;
-        }
-
-        const chunks: Buffer[] = [];
-        proxyRes.on('data', (chunk: Buffer) => chunks.push(chunk));
-        proxyRes.on('end', () => {
-            const html = injectTerminalReconnectScript(Buffer.concat(chunks).toString('utf8'));
-            const outHeaders = { ...proxyRes.headers };
-            // The body length changed and is now fixed: drop any stale length/
-            // encoding framing and set the real one.
-            delete outHeaders['content-encoding'];
-            delete outHeaders['transfer-encoding'];
-            outHeaders['content-length'] = Buffer.byteLength(html).toString();
-            res.writeHead(proxyRes.statusCode || 200, outHeaders);
-            res.end(html);
-        });
-        proxyRes.on('error', (err) => {
-            log.error('Shell proxy response error', { error: err.message });
-            if (!res.headersSent) res.status(502).type('text/plain').send('Shell proxy error');
-        });
-    });
-
-    proxyReq.on('error', (err) => {
-        // ECONNREFUSED means ttyd isn't listening — it almost always crashed on
-        // startup (see spawnTtyd, which records its last output in lastTtydError).
-        // Surface that as a 503 instead of an opaque 500 so the cause is visible.
-        const ttydDown = (err as NodeJS.ErrnoException).code === 'ECONNREFUSED';
-        log.error('Manual proxy error', { error: err.message, ttydDown });
-        if (!res.headersSent) {
-            if (ttydDown) {
-                res.status(503).type('text/plain').send(buildShellUnavailableMessage(lastTtydError));
-            } else {
-                res.status(502).type('text/plain').send(`Shell proxy error: ${err.message}`);
-            }
-        }
-    });
-
-    req.pipe(proxyReq);
-});
-
-// Manual WebSocket Proxy for ttyd
-const wsProxy = httpProxy.createProxyServer({
-    target: `http://127.0.0.1:${shellPort}`,
-    ws: true,
-});
-
-// Without this handler a WebSocket upgrade to a down ttyd emits an 'error' with
-// no listener, which Node escalates to an uncaught exception that can take down
-// the whole server. ttyd is restarted by spawnTtyd; just close the browser
-// socket so the terminal shows its reconnect overlay and retries.
-wsProxy.on('error', (err, _req, resOrSocket) => {
-    log.warning('Shell WebSocket proxy error', { error: (err as Error).message });
-    const socket = resOrSocket as Duplex | undefined;
-    if (socket && typeof socket.destroy === 'function' && !socket.destroyed) {
-        socket.destroy();
-    }
-});
-
+// WebSocket upgrades go to the shell or a bridge; anything else is refused.
 server.on('upgrade', (req, socket, head) => {
-    if (req.url?.startsWith('/shell')) {
-        req.url = req.url.replace(/^\/shell/, '') || '/';
-        req.url = translateLaunchParam(req.url);
-        log.info('Proxying shell WebSocket upgrade', { url: req.url });
-
-        // Track activity on WebSocket data
-        socket.on('data', () => {
-            lastActivityAt = Date.now();
-        });
-
-        wsProxy.ws(req, socket as Duplex, head);
-    } else {
-        // Check bridges
-        let matchedBridge: Bridge | null = null;
-        let matchedPath = '';
-
-        const reqPath = req.url || '/';
-        // Extract just the path without query string for matching
-        const pathOnly = reqPath.split('?')[0];
-
-        for (const bridge of getBridges()) {
-            if (pathOnly.startsWith(bridge.path) && bridge.path.length > matchedPath.length) {
-                matchedBridge = bridge;
-                matchedPath = bridge.path;
-            }
-        }
-
-        if (matchedBridge && bridgeProxies.has(matchedBridge.path)) {
-            const entry = bridgeProxies.get(matchedBridge.path)!;
-
-            // Get the extra path after the exposed path
-            let extraPath = pathOnly.slice(matchedBridge.path.length) || '';
-            const queryString = reqPath.includes('?') ? reqPath.slice(reqPath.indexOf('?')) : '';
-
-            // Build the new URL: targetPath + extraPath + query string
-            // Avoid double slashes when joining paths
-            let finalPath = entry.targetPath;
-            if (extraPath) {
-                if (finalPath.endsWith('/') && extraPath.startsWith('/')) {
-                    extraPath = extraPath.slice(1);
-                }
-                if (!finalPath.endsWith('/') && !extraPath.startsWith('/')) {
-                    finalPath += '/';
-                }
-                finalPath += extraPath;
-            }
-
-            req.url = finalPath + queryString;
-            if (!req.url.startsWith('/')) {
-                req.url = `/${  req.url}`;
-            }
-
-            log.info('Proxying dynamic WebSocket upgrade', {
-                exposedPath: matchedBridge.path,
-                targetUrl: entry.targetOrigin + req.url,
-            });
-
-            // Track activity
-            socket.on('data', () => {
-                lastActivityAt = Date.now();
-            });
-
-            entry.proxy.ws(req, socket as Duplex, head);
-        }
-    }
+    if (handleShellUpgrade(req, socket, head)) return;
+    if (handleBridgeUpgrade(req, socket, head)) return;
+    socket.destroy();
 });
 
 // ============================================================================
-// Bridges: dynamic reverse proxies for local servers
+// Start
 // ============================================================================
 
-// Live reverse-proxy instances backing each bridge
-interface BridgeProxy {
-    proxy: ReturnType<typeof httpProxy.createProxyServer>;
-    targetOrigin: string;
-    targetPath: string;
-}
-const bridgeProxies = new Map<string, BridgeProxy>();
-
-/**
- * Create or update the reverse proxy backing a bridge
- */
-const setupBridge = (bridge: Bridge): void => {
-    // Normalize target URL
-    let targetUrl = bridge.target;
-    if (!targetUrl.startsWith('http://') && !targetUrl.startsWith('https://')) {
-        targetUrl = `http://${targetUrl}`;
-    }
-
-    // Parse the target URL to extract origin and path
-    let targetOrigin: string;
-    let targetPath: string;
-    try {
-        const url = new URL(targetUrl);
-        targetOrigin = `${url.protocol}//${url.host}`;
-        targetPath = url.pathname || '/';
-        // Keep the target path as-is (preserve trailing slash if present)
-    } catch {
-        log.error('Invalid target URL', { target: targetUrl });
-        return;
-    }
-
-    // Remove existing proxy if any
-    if (bridgeProxies.has(bridge.path)) {
-        const oldEntry = bridgeProxies.get(bridge.path);
-        oldEntry?.proxy.close();
-    }
-
-    // Create new proxy targeting just the origin
-    const proxy = httpProxy.createProxyServer({
-        target: targetOrigin,
-        changeOrigin: true,
-        // Don't rewrite redirects - we remap paths ourselves
-        autoRewrite: false,
-    });
-
-    proxy.on('error', (err, _req, res) => {
-        log.error('Dynamic proxy error', { path: bridge.path, target: targetUrl, error: err.message });
-        if (res && 'writeHead' in res && !res.headersSent) {
-            res.writeHead(502, { 'Content-Type': 'text/plain' });
-            res.end(`Proxy error: target server at ${targetUrl} not available`);
-        }
-    });
-
-    // Rewrite Location headers in redirects to map target paths back to exposed paths
-    proxy.on('proxyRes', (proxyRes) => {
-        const {location} = proxyRes.headers;
-        if (location && typeof location === 'string') {
-            log.info('Proxy response with Location header', {
-                statusCode: proxyRes.statusCode,
-                location,
-                targetPath,
-                exposedPath: bridge.path
-            });
-            // If the location starts with the target path, rewrite it to the exposed path
-            if (location.startsWith(targetPath)) {
-                const newLocation = bridge.path + location.slice(targetPath.length);
-                proxyRes.headers.location = newLocation;
-                log.info('Rewrote redirect Location header', {
-                    original: location,
-                    rewritten: newLocation,
-                });
-            }
-        }
-    });
-
-    bridgeProxies.set(bridge.path, { proxy, targetOrigin, targetPath });
-    log.info('Proxy configured', { exposedPath: bridge.path, targetOrigin, targetPath });
-};
-
-/**
- * Tear down the reverse proxy for a bridge path
- */
-const removeBridgeProxy = (path: string): void => {
-    if (bridgeProxies.has(path)) {
-        const entry = bridgeProxies.get(path);
-        entry?.proxy.close();
-        bridgeProxies.delete(path);
-        log.info('Proxy removed', { path });
-    }
-};
-
-// Initialize proxies from current config
-for (const bridge of getBridges()) {
-    setupBridge(bridge);
-}
-
-// Listen for config changes and update proxies
-onBridgesChange((newBridges) => {
-    // Find removed bridges
-    const newPaths = new Set(newBridges.map((m) => m.path));
-    for (const path of bridgeProxies.keys()) {
-        if (!newPaths.has(path)) {
-            removeBridgeProxy(path);
-        }
-    }
-
-    // Add/update bridges
-    for (const bridge of newBridges) {
-        setupBridge(bridge);
-    }
-});
-
-// Bridge route handler - must be added BEFORE the 404 handler
-// This catches all requests to mapped paths
-app.use((req: Request, res: Response, next) => {
-    // Find the matching bridge (longest path match)
-    let matchedBridge: Bridge | null = null;
-    let matchedPath = '';
-
-    for (const bridge of getBridges()) {
-        if (req.path.startsWith(bridge.path) && bridge.path.length > matchedPath.length) {
-            matchedBridge = bridge;
-            matchedPath = bridge.path;
-        }
-    }
-
-    if (matchedBridge && bridgeProxies.has(matchedBridge.path)) {
-        const entry = bridgeProxies.get(matchedBridge.path)!;
-
-        // Get the extra path after the exposed path (e.g., /openclaw/foo -> /foo)
-        let extraPath = req.path.slice(matchedBridge.path.length) || '';
-
-        // Build the new URL: targetPath + extraPath + query string
-        const queryString = req.url.includes('?') ? req.url.slice(req.url.indexOf('?')) : '';
-
-        // Avoid double slashes when joining paths
-        let finalPath = entry.targetPath;
-        if (extraPath) {
-            // If targetPath ends with / and extraPath starts with /, remove one
-            if (finalPath.endsWith('/') && extraPath.startsWith('/')) {
-                extraPath = extraPath.slice(1);
-            }
-            // If neither has a slash between them, add one
-            if (!finalPath.endsWith('/') && !extraPath.startsWith('/')) {
-                finalPath += '/';
-            }
-            finalPath += extraPath;
-        }
-
-        req.url = finalPath + queryString;
-
-        // Ensure URL starts with /
-        if (!req.url.startsWith('/')) {
-            req.url = `/${  req.url}`;
-        }
-
-        log.info('Proxying request', {
-            originalPath: req.path,
-            exposedPath: matchedBridge.path,
-            extraPath,
-            targetPath: entry.targetPath,
-            finalUrl: req.url,
-            targetUrl: entry.targetOrigin + req.url,
-        });
-
-        // Track activity
-        lastActivityAt = Date.now();
-
-        entry.proxy.web(req, res);
-    } else {
-        next();
-    }
-});
-
-// Start server
 server.listen(port, () => {
     log.info(`Apify AI Code Sandbox listening on port ${port}`);
     log.info(`Server URL: ${serverUrl}`);
@@ -1343,18 +321,5 @@ server.listen(port, () => {
 
     console.log('=====================================\n');
 
-    // Start idle timeout check
-    idleTimeoutSecs = input?.idleTimeoutSecs ?? DEFAULT_IDLE_TIMEOUT_SECS;
-    if (idleTimeoutSecs > 0) {
-        log.info(`Idle timeout monitor started (${idleTimeoutSecs}s)`);
-        setInterval(async () => {
-            const idleTimeMs = Date.now() - lastActivityAt;
-            if (idleTimeMs > idleTimeoutSecs * 1000) {
-                const message = `Sandbox shut down after ${Math.round(idleTimeoutSecs)} seconds of inactivity.`;
-                log.warning(message);
-                await setStatusMessage('Sandbox is shutting down');
-                await Actor.exit({ statusMessage: message });
-            }
-        }, 30000); // Check every 30 seconds
-    }
+    startIdleMonitor();
 });

--- a/sandbox/src/mcp.ts
+++ b/sandbox/src/mcp.ts
@@ -4,28 +4,19 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { log } from 'apify';
 import * as z from 'zod';
 
-import { executeCode, listFiles, readFile, runCommand, writeFile } from './operations.js';
+import { execute, listFiles, normalizeLanguage, readFile, SUPPORTED_LANGUAGES, writeFile } from './operations.js';
 
-/**
- * Normalize language aliases to canonical form
- * @param lang - Language string (optional)
- * @returns Normalized language or null if invalid/not provided
- */
-const normalizeLanguage = (lang?: string): 'js' | 'ts' | 'py' | 'shell' | null => {
-    if (!lang) return null;
-    const lower = lang.toLowerCase();
-    const mapping: Record<string, 'js' | 'ts' | 'py' | 'shell'> = {
-        js: 'js',
-        javascript: 'js',
-        ts: 'ts',
-        typescript: 'ts',
-        py: 'py',
-        python: 'py',
-        bash: 'shell',
-        sh: 'shell',
-    };
-    return mapping[lower] || null;
-};
+/** Wrap an operation result as an MCP tool result (pretty-printed JSON). */
+const jsonResult = (value: unknown, isError = false): CallToolResult => ({
+    content: [{ type: 'text', text: JSON.stringify(value, null, 2) }],
+    ...(isError ? { isError: true } : {}),
+});
+
+/** Wrap an error message as a failed MCP tool result. */
+const errorResult = (message: string): CallToolResult => ({
+    content: [{ type: 'text', text: message }],
+    isError: true,
+});
 
 /**
  * Creates and configures the MCP server with all sandbox tools
@@ -78,61 +69,20 @@ export const createMcpServer = () => {
                     timeoutSecs,
                 });
 
-                // Normalize language
                 const normalizedLang = normalizeLanguage(language);
-
-                // Validate language
                 if (language && !normalizedLang) {
                     log.warning('MCP execute tool: invalid language', { language });
-                    return {
-                        content: [
-                            {
-                                type: 'text',
-                                text: `Invalid language: ${language}. Supported: js, javascript, ts, typescript, py, python, bash, sh`,
-                            },
-                        ],
-                        isError: true,
-                    };
+                    return errorResult(`Invalid language: ${language}. Supported: ${SUPPORTED_LANGUAGES}`);
                 }
 
-                // Convert timeout from seconds to milliseconds
-                const timeoutMs = timeoutSecs ? timeoutSecs * 1000 : undefined;
-
-                let result;
-
-                // Route to appropriate executor
-                if (!normalizedLang || normalizedLang === 'shell') {
-                    // Shell command execution
-                    result = await runCommand(command, cwd, timeoutMs);
-                    result = { ...result, language: 'shell' };
-                } else {
-                    // Code execution
-                    result = await executeCode(command, normalizedLang, timeoutMs, cwd);
-                }
+                const result = await execute({ command, language: normalizedLang, cwd, timeoutSecs });
 
                 log.info('MCP execute tool completed', { language: result.language, exitCode: result.exitCode });
-
-                return {
-                    content: [
-                        {
-                            type: 'text',
-                            text: JSON.stringify(result, null, 2),
-                        },
-                    ],
-                    isError: result.exitCode !== 0,
-                };
+                return jsonResult(result, result.exitCode !== 0);
             } catch (error) {
                 const err = error as Error;
                 log.error('MCP execute tool error', { error: err.message });
-                return {
-                    content: [
-                        {
-                            type: 'text',
-                            text: `Error executing: ${err.message}`,
-                        },
-                    ],
-                    isError: true,
-                };
+                return errorResult(`Error executing: ${err.message}`);
             }
         },
     );
@@ -155,38 +105,15 @@ export const createMcpServer = () => {
 
                 if (!result.success) {
                     log.warning('MCP write-file tool failed', { path, error: result.error });
-                    return {
-                        content: [
-                            {
-                                type: 'text',
-                                text: JSON.stringify(result, null, 2),
-                            },
-                        ],
-                        isError: true,
-                    };
+                    return jsonResult(result, true);
                 }
 
                 log.info('MCP write-file tool completed successfully', { path });
-                return {
-                    content: [
-                        {
-                            type: 'text',
-                            text: JSON.stringify(result, null, 2),
-                        },
-                    ],
-                };
+                return jsonResult(result);
             } catch (error) {
                 const err = error as Error;
                 log.error('MCP write-file tool error', { path, error: err.message });
-                return {
-                    content: [
-                        {
-                            type: 'text',
-                            text: `Error writing file: ${err.message}`,
-                        },
-                    ],
-                    isError: true,
-                };
+                return errorResult(`Error writing file: ${err.message}`);
             }
         },
     );
@@ -208,38 +135,15 @@ export const createMcpServer = () => {
 
                 if (result.error) {
                     log.warning('MCP read-file tool failed', { path, error: result.error });
-                    return {
-                        content: [
-                            {
-                                type: 'text',
-                                text: JSON.stringify(result, null, 2),
-                            },
-                        ],
-                        isError: true,
-                    };
+                    return jsonResult(result, true);
                 }
 
                 log.info('MCP read-file tool completed successfully', { path, contentLength: result.content?.length });
-                return {
-                    content: [
-                        {
-                            type: 'text',
-                            text: JSON.stringify(result, null, 2),
-                        },
-                    ],
-                };
+                return jsonResult(result);
             } catch (error) {
                 const err = error as Error;
                 log.error('MCP read-file tool error', { path, error: err.message });
-                return {
-                    content: [
-                        {
-                            type: 'text',
-                            text: `Error reading file: ${err.message}`,
-                        },
-                    ],
-                    isError: true,
-                };
+                return errorResult(`Error reading file: ${err.message}`);
             }
         },
     );
@@ -260,41 +164,18 @@ export const createMcpServer = () => {
 
                 if (result.error) {
                     log.warning('MCP list-files tool failed', { path, error: result.error });
-                    return {
-                        content: [
-                            {
-                                type: 'text',
-                                text: JSON.stringify(result, null, 2),
-                            },
-                        ],
-                        isError: true,
-                    };
+                    return jsonResult(result, true);
                 }
 
                 log.info('MCP list-files tool completed successfully', {
                     path: result.path,
                     fileCount: result.files.length,
                 });
-                return {
-                    content: [
-                        {
-                            type: 'text',
-                            text: JSON.stringify(result, null, 2),
-                        },
-                    ],
-                };
+                return jsonResult(result);
             } catch (error) {
                 const err = error as Error;
                 log.error('MCP list-files tool error', { path, error: err.message });
-                return {
-                    content: [
-                        {
-                            type: 'text',
-                            text: `Error listing files: ${err.message}`,
-                        },
-                    ],
-                    isError: true,
-                };
+                return errorResult(`Error listing files: ${err.message}`);
             }
         },
     );

--- a/sandbox/src/operations.ts
+++ b/sandbox/src/operations.ts
@@ -221,6 +221,34 @@ export const listFiles = async (
     }
 };
 
+/** Canonical execution languages; 'shell' runs via bash, the rest via interpreters. */
+export type ExecLanguage = 'js' | 'ts' | 'py' | 'shell';
+
+/** Accepted language aliases mapped to their canonical names. */
+const LANGUAGE_ALIASES: Record<string, ExecLanguage> = {
+    js: 'js',
+    javascript: 'js',
+    ts: 'ts',
+    typescript: 'ts',
+    py: 'py',
+    python: 'py',
+    bash: 'shell',
+    sh: 'shell',
+};
+
+/** Human-readable list of accepted language values, for input-error messages. */
+export const SUPPORTED_LANGUAGES = Object.keys(LANGUAGE_ALIASES).join(', ');
+
+/**
+ * Normalize a language alias to canonical form. Returns null when the value is
+ * missing or unrecognized — callers must treat a provided-but-unrecognized
+ * language as an input error rather than defaulting to shell.
+ */
+export const normalizeLanguage = (lang?: string): ExecLanguage | null => {
+    if (!lang) return null;
+    return LANGUAGE_ALIASES[lang.toLowerCase()] || null;
+};
+
 /**
  * Execute code in a specified language (JS, TS, or Python)
  *
@@ -349,6 +377,27 @@ export const executeCode = async (
             }
         }
     }
+};
+
+/**
+ * Run a shell command or code snippet, dispatching on the normalized language
+ * (null or 'shell' → bash via runCommand; js/ts/py → executeCode). Shared
+ * entry point for the /exec REST endpoint and the MCP `execute` tool.
+ */
+export const execute = async (options: {
+    command: string;
+    language: ExecLanguage | null;
+    cwd?: string;
+    timeoutSecs?: number;
+}): Promise<{ stdout: string; stderr: string; exitCode: number; language: string }> => {
+    const { command, language, cwd, timeoutSecs } = options;
+    const timeoutMs = timeoutSecs ? timeoutSecs * 1000 : undefined;
+
+    if (!language || language === 'shell') {
+        const result = await runCommand(command, cwd, timeoutMs);
+        return { ...result, language: 'shell' };
+    }
+    return executeCode(command, language, timeoutMs, cwd);
 };
 
 /**
@@ -713,10 +762,11 @@ export const createZipArchive = async (
             zlib: { level: 6 }, // Compression level
         });
 
-        // Add error handling for the archive
+        // Log archive errors instead of throwing: this fires asynchronously while
+        // the archive streams, and throwing from an event handler would crash the
+        // process. The consumer sees the stream end/error instead.
         archive.on('error', (err) => {
             log.error('Archive error', { error: err.message });
-            throw err;
         });
 
         // Add directory contents to archive

--- a/sandbox/src/route-params.ts
+++ b/sandbox/src/route-params.ts
@@ -1,0 +1,19 @@
+/**
+ * Express 5 route-parameter helpers.
+ *
+ * In Express 5 (path-to-regexp v8), a named wildcard like `/fs/*path` captures
+ * the matched segments as an ARRAY (`/fs/a/b.txt` → `['a', 'b.txt']`), not a
+ * string. Coercing that with `String(...)` joins the segments with commas
+ * (`'a,b.txt'`), silently corrupting every nested path — which is exactly the
+ * bug the Express 4 → 5 migration introduced. Always go through this helper.
+ */
+
+/**
+ * Convert a wildcard route param (`req.params.<name>`) back into the matched
+ * URL path, joining segments with `/`. Returns `''` when the param is absent.
+ */
+export const wildcardPath = (param: unknown): string => {
+    if (param === undefined || param === null) return '';
+    if (Array.isArray(param)) return param.map(String).join('/');
+    return String(param);
+};

--- a/sandbox/src/routes/bridges.ts
+++ b/sandbox/src/routes/bridges.ts
@@ -1,0 +1,107 @@
+/**
+ * Bridge configuration API mounted at /bridges. CRUD over the exposed-path →
+ * local-target list; the live reverse proxies react to these changes via
+ * bridges.ts change notifications (see bridge-proxy.ts).
+ */
+import { log } from 'apify';
+import type { Request, Response } from 'express';
+import { Router } from 'express';
+
+import { addBridge, getBridges, removeBridge, saveBridges } from '../bridges.js';
+import { wildcardPath } from '../route-params.js';
+
+// GET / - Current bridges
+const handleGet = (_req: Request, res: Response): void => {
+    try {
+        res.json({ bridges: getBridges() });
+    } catch (error) {
+        log.error('Failed to get bridges', { error: (error as Error).message });
+        res.status(500).json({ error: (error as Error).message });
+    }
+};
+
+// PUT / - Replace all bridges
+const handlePut = (req: Request, res: Response): void => {
+    try {
+        const { bridges } = req.body;
+
+        if (!Array.isArray(bridges)) {
+            res.status(400).json({ error: 'bridges must be an array' });
+            return;
+        }
+
+        for (const bridge of bridges) {
+            if (!bridge.path || typeof bridge.path !== 'string') {
+                res.status(400).json({ error: 'Each bridge must have a path string' });
+                return;
+            }
+            if (!bridge.target || typeof bridge.target !== 'string') {
+                res.status(400).json({
+                    error: 'Each bridge must have a target string (full URL like http://127.0.0.1:3000/myapp)',
+                });
+                return;
+            }
+        }
+
+        saveBridges(bridges);
+        log.info('Bridges updated via API', { count: bridges.length });
+        res.json({ success: true, bridges: getBridges() });
+    } catch (error) {
+        log.error('Failed to update bridges', { error: (error as Error).message });
+        res.status(500).json({ error: (error as Error).message });
+    }
+};
+
+// POST / - Add a single bridge
+const handlePost = (req: Request, res: Response): void => {
+    try {
+        const { path, target } = req.body;
+
+        if (!path || typeof path !== 'string') {
+            res.status(400).json({ error: 'path is required (e.g., /myapp)' });
+            return;
+        }
+        if (!target || typeof target !== 'string') {
+            res.status(400).json({ error: 'target is required (full URL like http://127.0.0.1:3000/myapp)' });
+            return;
+        }
+
+        addBridge({ path, target });
+        log.info('Bridge added via API', { path, target });
+        res.json({ success: true, bridges: getBridges() });
+    } catch (error) {
+        log.error('Failed to add bridge', { error: (error as Error).message });
+        res.status(500).json({ error: (error as Error).message });
+    }
+};
+
+// DELETE /*path - Remove the bridge exposed at that path
+const handleDelete = (req: Request, res: Response): void => {
+    try {
+        const pathToRemove = `/${wildcardPath(req.params.path)}`;
+
+        const removed = removeBridge(pathToRemove);
+        if (removed) {
+            log.info('Bridge removed via API', { path: pathToRemove });
+            res.json({ success: true, removed: pathToRemove, bridges: getBridges() });
+        } else {
+            res.status(404).json({ error: 'Bridge not found', path: pathToRemove });
+        }
+    } catch (error) {
+        log.error('Failed to remove bridge', { error: (error as Error).message });
+        res.status(500).json({ error: (error as Error).message });
+    }
+};
+
+/**
+ * Build the /bridges router. Mount with `app.use('/bridges', ...)` AFTER
+ * express.json() — the PUT/POST bodies are JSON.
+ */
+export const createBridgesRouter = (): Router => {
+    const router = Router();
+    router.get('/', handleGet);
+    router.put('/', handlePut);
+    router.post('/', handlePost);
+    router.delete('/*path', handleDelete);
+    return router;
+};

--- a/sandbox/src/routes/exec.ts
+++ b/sandbox/src/routes/exec.ts
@@ -1,0 +1,47 @@
+/**
+ * POST /exec — unified shell-command and code-snippet execution endpoint.
+ * Register AFTER express.json(); the request body is JSON.
+ */
+import { log } from 'apify';
+import type { Request, Response } from 'express';
+
+import { execute, normalizeLanguage, SUPPORTED_LANGUAGES } from '../operations.js';
+
+export const handleExec = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const { command, language, cwd, timeoutSecs } = req.body;
+
+        log.info('REST /exec request received', { command: command?.substring(0, 100), language, cwd, timeoutSecs });
+
+        if (!command) {
+            res.status(400).json({ error: 'Command is required' });
+            return;
+        }
+
+        const normalizedLang = normalizeLanguage(language);
+        if (language && !normalizedLang) {
+            res.status(400).json({ error: `Invalid language: ${language}. Supported: ${SUPPORTED_LANGUAGES}` });
+            return;
+        }
+
+        const result = await execute({ command, language: normalizedLang, cwd, timeoutSecs });
+
+        if (result.exitCode !== 0) {
+            log.debug('REST /exec completed with error', { language: result.language, exitCode: result.exitCode });
+            res.status(500).json(result);
+            return;
+        }
+
+        log.info('REST /exec completed successfully', { language: result.language });
+        res.json(result);
+    } catch (error) {
+        log.error('REST /exec error', { error });
+        res.status(500).json({
+            error: (error as Error).message,
+            stdout: '',
+            stderr: '',
+            exitCode: 1,
+            language: 'shell',
+        });
+    }
+};

--- a/sandbox/src/routes/fs.ts
+++ b/sandbox/src/routes/fs.ts
@@ -1,0 +1,297 @@
+/**
+ * RESTful filesystem API mounted at /fs.
+ *
+ * Paths are taken from the URL (`/fs/<path>`) and resolved relative to
+ * /sandbox by the operations layer. The router's own routes treat `/` and
+ * `/*path` with the same handlers, so the /fs root needs no special-cased
+ * copies.
+ *
+ * IMPORTANT: this router must be mounted BEFORE express.json() — PUT/POST
+ * bodies are raw bytes (any content type), and the JSON body parser would
+ * consume them.
+ */
+import { log } from 'apify';
+import type { Request, Response } from 'express';
+import express, { Router } from 'express';
+import mime from 'mime-types';
+
+import {
+    appendFile,
+    createDirectory,
+    createZipArchive,
+    deleteFileOrDirectory,
+    listFilesDetailed,
+    readFileBinary,
+    statPath,
+    writeFileBinary,
+} from '../operations.js';
+import { wildcardPath } from '../route-params.js';
+
+/** Raw request bodies up to this size are accepted for PUT and POST. */
+const RAW_BODY_LIMIT = '500mb';
+
+/** The sandbox-relative path addressed by the request ('' = /sandbox root). */
+const requestedPath = (req: Request): string => wildcardPath(req.params.path);
+
+// HEAD / and /*path - File or directory metadata
+const handleHead = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const filePath = requestedPath(req);
+        log.info('REST HEAD /fs request received', { path: filePath });
+
+        const result = await statPath(filePath);
+
+        if (!result.exists || result.error) {
+            log.warning('REST HEAD /fs failed', { path: filePath, error: result.error });
+            res.status(404).end();
+            return;
+        }
+
+        res.setHeader('X-File-Type', result.type);
+        res.setHeader('X-Path', result.path);
+
+        if (result.mtime) {
+            res.setHeader('Last-Modified', result.mtime.toUTCString());
+        }
+
+        if (result.type === 'file' && result.size !== undefined) {
+            res.setHeader('Content-Length', result.size.toString());
+            res.setHeader('Content-Type', mime.lookup(result.path) || 'application/octet-stream');
+        }
+
+        log.info('REST HEAD /fs completed successfully', { path: result.path, type: result.type });
+        res.status(200).end();
+    } catch (error) {
+        log.error('REST HEAD /fs error', { error });
+        res.status(500).end();
+    }
+};
+
+// GET / and /*path - Read file, list directory, or download directory as ZIP
+const handleGet = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const filePath = requestedPath(req);
+        const download = req.query.download === '1';
+
+        log.info('REST GET /fs request received', { path: filePath, download });
+
+        const statResult = await statPath(filePath);
+
+        if (!statResult.exists || statResult.error) {
+            log.warning('REST GET /fs failed', { path: filePath, error: statResult.error });
+            res.status(404).json({ error: statResult.error || 'Path not found', path: filePath });
+            return;
+        }
+
+        if (statResult.type === 'directory') {
+            if (download) {
+                const zipResult = await createZipArchive(filePath);
+
+                if (zipResult.error || !zipResult.stream) {
+                    log.warning('REST GET /fs ZIP creation failed', { path: filePath, error: zipResult.error });
+                    res.status(500).json({ error: zipResult.error || 'Failed to create ZIP archive' });
+                    return;
+                }
+
+                const dirName = filePath.split('/').filter(Boolean).pop() || 'sandbox';
+                res.setHeader('Content-Type', 'application/zip');
+                res.setHeader('Content-Disposition', `attachment; filename="${dirName}.zip"`);
+
+                log.info('REST GET /fs streaming ZIP', { path: zipResult.path });
+                zipResult.stream.on('error', (err) => {
+                    log.error('REST GET /fs ZIP stream error', { path: zipResult.path, error: err.message });
+                    res.end();
+                });
+                zipResult.stream.pipe(res);
+            } else {
+                const listResult = await listFilesDetailed(filePath);
+
+                if (listResult.error) {
+                    log.warning('REST GET /fs directory listing failed', { path: filePath, error: listResult.error });
+                    res.status(500).json({ error: listResult.error, path: filePath });
+                    return;
+                }
+
+                log.info('REST GET /fs directory listing completed', {
+                    path: listResult.path,
+                    entryCount: listResult.entries.length,
+                });
+                res.json(listResult);
+            }
+        } else {
+            // File: return raw bytes with appropriate Content-Type
+            const fileResult = await readFileBinary(filePath);
+
+            if (fileResult.error || !fileResult.content) {
+                log.warning('REST GET /fs file read failed', { path: filePath, error: fileResult.error });
+                res.status(404).json({ error: fileResult.error || 'Failed to read file', path: filePath });
+                return;
+            }
+
+            res.setHeader('Content-Type', fileResult.mimeType || 'application/octet-stream');
+
+            if (download) {
+                const fileName = filePath.split('/').filter(Boolean).pop() || 'file';
+                res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
+            }
+
+            log.info('REST GET /fs file read completed', {
+                path: fileResult.path,
+                size: fileResult.size,
+                mimeType: fileResult.mimeType,
+            });
+            res.send(fileResult.content);
+        }
+    } catch (error) {
+        log.error('REST GET /fs error', { error });
+        res.status(500).json({ error: (error as Error).message });
+    }
+};
+
+// PUT /*path - Write/replace file
+const handlePut = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const filePath = requestedPath(req);
+        const content = req.body;
+
+        log.info('REST PUT /fs request received', {
+            path: filePath,
+            contentLength: content?.length,
+            contentType: req.headers['content-type'],
+        });
+
+        if (!filePath || filePath === '/') {
+            res.status(400).json({ error: 'Cannot write to root directory' });
+            return;
+        }
+
+        if (!content) {
+            res.status(400).json({ error: 'Content is required' });
+            return;
+        }
+
+        const result = await writeFileBinary(filePath, content);
+
+        if (!result.success) {
+            log.warning('REST PUT /fs failed', { path: filePath, error: result.error });
+            res.status(500).json({ error: result.error, path: filePath });
+            return;
+        }
+
+        log.info('REST PUT /fs completed successfully', { path: result.path, size: result.size });
+        res.status(200).json({ success: true, path: result.path, size: result.size });
+    } catch (error) {
+        log.error('REST PUT /fs error', { error });
+        res.status(500).json({ error: (error as Error).message });
+    }
+};
+
+// POST /*path - Create directory (?mkdir=1) or append to file (?append=1)
+const handlePost = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const filePath = requestedPath(req);
+        const mkdir = req.query.mkdir === '1';
+        const append = req.query.append === '1';
+
+        log.info('REST POST /fs request received', { path: filePath, mkdir, append });
+
+        if (!filePath || filePath === '/') {
+            res.status(400).json({ error: 'Cannot operate on root directory' });
+            return;
+        }
+
+        if (!mkdir && !append) {
+            res.status(400).json({ error: 'Either mkdir=1 or append=1 query parameter is required' });
+            return;
+        }
+
+        if (mkdir && append) {
+            res.status(400).json({ error: 'Cannot use both mkdir=1 and append=1' });
+            return;
+        }
+
+        if (mkdir) {
+            const result = await createDirectory(filePath);
+
+            if (!result.success) {
+                log.warning('REST POST /fs mkdir failed', { path: filePath, error: result.error });
+                res.status(500).json({ error: result.error, path: filePath });
+                return;
+            }
+
+            log.info('REST POST /fs mkdir completed successfully', { path: result.path });
+            res.status(201).json({ success: true, path: result.path, type: 'directory' });
+        } else {
+            const content = req.body;
+
+            if (!content) {
+                res.status(400).json({ error: 'Content is required for append operation' });
+                return;
+            }
+
+            const result = await appendFile(filePath, content);
+
+            if (!result.success) {
+                log.warning('REST POST /fs append failed', { path: filePath, error: result.error });
+                res.status(500).json({ error: result.error, path: filePath });
+                return;
+            }
+
+            log.info('REST POST /fs append completed successfully', { path: result.path, size: result.size });
+            res.status(200).json({ success: true, path: result.path, size: result.size });
+        }
+    } catch (error) {
+        log.error('REST POST /fs error', { error });
+        res.status(500).json({ error: (error as Error).message });
+    }
+};
+
+// DELETE /*path - Delete file or directory (?recursive=1 for non-empty dirs)
+const handleDelete = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const filePath = requestedPath(req);
+        const recursive = req.query.recursive === '1';
+
+        log.info('REST DELETE /fs request received', { path: filePath, recursive });
+
+        if (!filePath || filePath === '/') {
+            res.status(400).json({ error: 'Cannot delete root directory' });
+            return;
+        }
+
+        const result = await deleteFileOrDirectory(filePath, recursive);
+
+        if (!result.success) {
+            if (result.error?.includes('not empty')) {
+                log.warning('REST DELETE /fs failed - directory not empty', { path: filePath, error: result.error });
+                res.status(409).json({ error: result.error, path: filePath, code: 'DIRECTORY_NOT_EMPTY' });
+                return;
+            }
+
+            log.warning('REST DELETE /fs failed', { path: filePath, error: result.error });
+            res.status(500).json({ error: result.error, path: filePath });
+            return;
+        }
+
+        log.info('REST DELETE /fs completed successfully', { path: result.path });
+        res.status(200).json({ success: true, path: result.path, deleted: true });
+    } catch (error) {
+        log.error('REST DELETE /fs error', { error });
+        res.status(500).json({ error: (error as Error).message });
+    }
+};
+
+/** Build the /fs router. Mount with `app.use('/fs', createFsRouter())`. */
+export const createFsRouter = (): Router => {
+    const router = Router();
+    const rawBody = express.raw({ type: '*/*', limit: RAW_BODY_LIMIT });
+
+    // '/' covers /fs and /fs/; '/*path' covers everything below.
+    router.head(['/', '/*path'], handleHead);
+    router.get(['/', '/*path'], handleGet);
+    router.put('/*path', rawBody, handlePut);
+    router.post('/*path', rawBody, handlePost);
+    router.delete('/*path', handleDelete);
+
+    return router;
+};

--- a/sandbox/src/routes/mcp.ts
+++ b/sandbox/src/routes/mcp.ts
@@ -1,0 +1,39 @@
+/**
+ * POST /mcp — Streamable HTTP transport for the sandbox MCP server. Each
+ * request gets a fresh stateless server/transport pair (no session ids).
+ * Register AFTER express.json(); the JSON-RPC body arrives parsed.
+ */
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { log } from 'apify';
+import type { Request, Response } from 'express';
+
+import { createMcpServer } from '../mcp.js';
+
+export const handleMcp = async (req: Request, res: Response): Promise<void> => {
+    log.info('MCP request received', { body: req.body });
+    const mcpServer = createMcpServer();
+    try {
+        const transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: undefined,
+        });
+        await mcpServer.connect(transport);
+        await transport.handleRequest(req, res, req.body);
+        res.on('close', () => {
+            log.info('MCP request closed');
+            void transport.close();
+            void mcpServer.close();
+        });
+    } catch (error) {
+        log.error('MCP request error', { error });
+        if (!res.headersSent) {
+            res.status(500).json({
+                jsonrpc: '2.0',
+                error: {
+                    code: -32603,
+                    message: 'Internal server error',
+                },
+                id: null,
+            });
+        }
+    }
+};

--- a/sandbox/src/shell-launch.ts
+++ b/sandbox/src/shell-launch.ts
@@ -41,10 +41,7 @@ export const translateLaunchParam = (path: string): string => {
     params.delete('launch');
     const cmd = buildLaunchCommand(launch);
 
-    const parts: string[] = [
-        `arg=${encodeURIComponent('-c')}`,
-        `arg=${encodeURIComponent(cmd)}`,
-    ];
+    const parts: string[] = [`arg=${encodeURIComponent('-c')}`, `arg=${encodeURIComponent(cmd)}`];
     const rest = params.toString();
     if (rest) parts.push(rest);
 

--- a/sandbox/src/shell-server.ts
+++ b/sandbox/src/shell-server.ts
@@ -1,0 +1,247 @@
+/**
+ * Interactive shell backend: supervises the ttyd process and proxies /shell
+ * traffic (HTTP and WebSocket) to it.
+ *
+ * The pure decision logic lives in sibling modules so it can be unit-tested:
+ *   - ttyd.ts          — restart backoff, crash detection, output capture
+ *   - shell-launch.ts  — `?launch=<cmd>` → ttyd `?arg=...` URL translation
+ *   - templates/shell.ts — bashrc/welcome scripts and the reconnect overlay
+ *
+ * There is deliberately no server-side shutdown banner. Most stops (run
+ * timeout, hard abort, platform scale-down) kill the container with a signal
+ * and no advance event — the Apify SDK installs no SIGTERM/SIGINT handlers,
+ * it's driven by the platform events WebSocket — and a dying process can't
+ * reliably flush a message to the browser anyway. Instead the terminal page
+ * relabels ttyd's own reconnect overlay client-side; see
+ * injectTerminalReconnectScript (it shows "Actor probably finished" when a
+ * retry fails).
+ */
+import { spawn } from 'node:child_process';
+import { chmodSync, mkdirSync, writeFileSync } from 'node:fs';
+import type { IncomingMessage } from 'node:http';
+import http from 'node:http';
+import type { Duplex } from 'node:stream';
+
+import { log } from 'apify';
+import type { Express, Request, Response } from 'express';
+import httpProxy from 'http-proxy';
+
+import { SANDBOX_DIR } from './consts.js';
+import { touchActivity } from './idle.js';
+import { translateLaunchParam } from './shell-launch.js';
+import { injectTerminalReconnectScript, SANDBOX_BASHRC, WELCOME_SCRIPT } from './templates/shell.js';
+import {
+    appendTtydOutput,
+    buildShellUnavailableMessage,
+    isTtydStartupCrash,
+    nextTtydRestartDelayMs,
+    TTYD_RESTART_MIN_MS,
+} from './ttyd.js';
+
+const SHELL_PORT = 7681;
+
+// ttyd's last words: the tail of its stdout/stderr (or a spawn error). Recorded
+// so a crash — e.g. a missing shared library — shows up in the Actor log and in
+// the /shell proxy response instead of a bare exit code. The delay grows as ttyd
+// keeps failing to start (see nextTtydRestartDelayMs).
+let lastTtydError = '';
+let ttydRestartDelayMs = TTYD_RESTART_MIN_MS;
+
+/**
+ * Write the rcfile and welcome script that ttyd's bash sessions source.
+ * Must run before spawnTtyd().
+ */
+const writeShellFiles = (): void => {
+    try {
+        log.info('Writing shell environment files...');
+        mkdirSync('/app', { recursive: true });
+        writeFileSync('/app/welcome.sh', WELCOME_SCRIPT);
+        chmodSync('/app/welcome.sh', 0o755);
+        writeFileSync('/app/sandbox_bashrc', SANDBOX_BASHRC);
+        log.info('Shell environment files written successfully');
+    } catch (err) {
+        log.error('Failed to write shell environment files', { error: (err as Error).message });
+    }
+};
+
+/** Spawn ttyd, restarting it whenever it exits (with backoff on startup crashes). */
+const spawnTtyd = (): void => {
+    log.info('Spawning ttyd process...', { port: SHELL_PORT });
+    const startedAt = Date.now();
+
+    // Run ttyd with custom bashrc for better UX and environment alignment. Pipe
+    // its stdio (rather than ignoring it) so a startup failure is captured.
+    const ttyd = spawn('ttyd', ['-p', SHELL_PORT.toString(), '-a', '-W', 'bash', '--rcfile', '/app/sandbox_bashrc'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        cwd: SANDBOX_DIR,
+        env: { ...process.env },
+    });
+
+    // Keep only the tail of ttyd's output — its startup/error messages are short.
+    let recentOutput = '';
+    const capture = (chunk: Buffer): void => {
+        recentOutput = appendTtydOutput(recentOutput, chunk.toString());
+    };
+    ttyd.stdout?.on('data', capture);
+    ttyd.stderr?.on('data', capture);
+
+    // Schedule exactly one restart per spawn: a failed spawn emits 'error' (no
+    // 'exit'), a started process emits 'exit'; guard against both firing.
+    let settled = false;
+    const restartAfter = (crashed: boolean): void => {
+        if (settled) return;
+        settled = true;
+        const delay = crashed ? ttydRestartDelayMs : TTYD_RESTART_MIN_MS;
+        ttydRestartDelayMs = nextTtydRestartDelayMs(ttydRestartDelayMs, crashed);
+        setTimeout(spawnTtyd, delay);
+    };
+
+    ttyd.on('error', (err) => {
+        lastTtydError = err.message;
+        log.error('Failed to start ttyd', { error: err.message });
+        restartAfter(true);
+    });
+
+    ttyd.on('exit', (code, signal) => {
+        const aliveMs = Date.now() - startedAt;
+        const output = recentOutput.trim();
+        if (output) lastTtydError = output;
+
+        // A fast exit means ttyd never really came up (missing shared library,
+        // port already bound, bad args). Shout, since the old fixed-5s retry with
+        // no detail produced an invisible crash loop behind "Shell Proxy Error".
+        const crashed = isTtydStartupCrash(aliveMs);
+        if (crashed) {
+            log.error('ttyd exited immediately — interactive shell is unavailable', {
+                code,
+                signal,
+                aliveMs,
+                output: output || '(no output captured)',
+            });
+        } else {
+            log.warning('ttyd process exited; restarting', { code, signal, aliveMs });
+        }
+        restartAfter(crashed);
+    });
+};
+
+/** Write the shell environment files and start (and keep restarting) ttyd. */
+export const startShellBackend = (): void => {
+    writeShellFiles();
+    spawnTtyd();
+};
+
+/** Strip the /shell prefix and translate `?launch=` into ttyd's `?arg=` form. */
+const toTtydUrl = (url: string): string => {
+    let path = url.replace(/^\/shell/, '') || '/';
+    // Ensure path starts with / (handle query strings like ?arg=...)
+    if (path.startsWith('?')) {
+        path = `/${path}`;
+    }
+    return translateLaunchParam(path);
+};
+
+/** Manual HTTP proxy handler for ttyd. */
+const proxyShellRequest = (req: Request, res: Response): void => {
+    // Ask ttyd for an uncompressed response so the terminal HTML can be rewritten
+    // (see injectTerminalReconnectScript below). ttyd's assets are tiny, so losing
+    // gzip here is negligible.
+    const headers = { ...req.headers, 'accept-encoding': 'identity' };
+    const options = {
+        hostname: '127.0.0.1',
+        port: SHELL_PORT,
+        path: toTtydUrl(req.url),
+        method: req.method,
+        headers,
+    };
+
+    const proxyReq = http.request(options, (proxyRes) => {
+        // Inject the client-side reconnect notice into ttyd's terminal page. The
+        // server can't reliably push a shutdown message as the container is killed,
+        // so the browser relabels ttyd's reconnect overlay instead. Only the HTML
+        // document is rewritten; every other asset and status is piped through.
+        const isHtml = (proxyRes.headers['content-type'] || '').includes('text/html');
+        if (!isHtml) {
+            if (proxyRes.statusCode) {
+                res.writeHead(proxyRes.statusCode, proxyRes.headers);
+            }
+            proxyRes.pipe(res);
+            return;
+        }
+
+        const chunks: Buffer[] = [];
+        proxyRes.on('data', (chunk: Buffer) => chunks.push(chunk));
+        proxyRes.on('end', () => {
+            const html = injectTerminalReconnectScript(Buffer.concat(chunks).toString('utf8'));
+            const outHeaders = { ...proxyRes.headers };
+            // The body length changed and is now fixed: drop any stale length/
+            // encoding framing and set the real one.
+            delete outHeaders['content-encoding'];
+            delete outHeaders['transfer-encoding'];
+            outHeaders['content-length'] = Buffer.byteLength(html).toString();
+            res.writeHead(proxyRes.statusCode || 200, outHeaders);
+            res.end(html);
+        });
+        proxyRes.on('error', (err) => {
+            log.error('Shell proxy response error', { error: err.message });
+            if (!res.headersSent) res.status(502).type('text/plain').send('Shell proxy error');
+        });
+    });
+
+    proxyReq.on('error', (err) => {
+        // ECONNREFUSED means ttyd isn't listening — it almost always crashed on
+        // startup (see spawnTtyd, which records its last output in lastTtydError).
+        // Surface that as a 503 instead of an opaque 500 so the cause is visible.
+        const ttydDown = (err as NodeJS.ErrnoException).code === 'ECONNREFUSED';
+        log.error('Shell proxy error', { error: err.message, ttydDown });
+        if (!res.headersSent) {
+            if (ttydDown) {
+                res.status(503).type('text/plain').send(buildShellUnavailableMessage(lastTtydError));
+            } else {
+                res.status(502).type('text/plain').send(`Shell proxy error: ${err.message}`);
+            }
+        }
+    });
+
+    req.pipe(proxyReq);
+};
+
+/** Register the /shell HTTP proxy routes on the Express app. */
+export const registerShellRoutes = (app: Express): void => {
+    app.all('/shell{*rest}', proxyShellRequest);
+};
+
+// WebSocket proxy for ttyd's terminal connection. Without the error handler, a
+// WebSocket upgrade to a down ttyd emits an 'error' with no listener, which
+// Node escalates to an uncaught exception that can take down the whole server.
+// ttyd is restarted by spawnTtyd; just close the browser socket so the terminal
+// shows its reconnect overlay and retries.
+const wsProxy = httpProxy.createProxyServer({
+    target: `http://127.0.0.1:${SHELL_PORT}`,
+    ws: true,
+});
+
+wsProxy.on('error', (err, _req, resOrSocket) => {
+    log.warning('Shell WebSocket proxy error', { error: (err as Error).message });
+    const socket = resOrSocket as Duplex | undefined;
+    if (socket && typeof socket.destroy === 'function' && !socket.destroyed) {
+        socket.destroy();
+    }
+});
+
+/**
+ * Proxy a /shell WebSocket upgrade to ttyd. Returns false (untouched request)
+ * for non-shell URLs so the caller can try other upgrade handlers.
+ */
+export const handleShellUpgrade = (req: IncomingMessage, socket: Duplex, head: Buffer): boolean => {
+    if (!req.url?.startsWith('/shell')) return false;
+
+    req.url = toTtydUrl(req.url);
+    log.info('Proxying shell WebSocket upgrade', { url: req.url });
+
+    // Terminal keystrokes count as sandbox activity.
+    socket.on('data', touchActivity);
+
+    wsProxy.ws(req, socket, head);
+    return true;
+};

--- a/sandbox/src/templates/landing.ejs
+++ b/sandbox/src/templates/landing.ejs
@@ -125,7 +125,12 @@
         </section>
 
         <section class="card">
-            <h2><span class="section-icon">📁</span> Filesystem API <code class="section-path">/fs</code></h2>
+            <div class="card-header">
+                <h2><span class="section-icon">📁</span> Filesystem API <code class="section-path">/fs</code></h2>
+                <div class="actions" data-no-md>
+                    <a class="button" href="/browse" target="_blank" rel="noopener noreferrer"><span class="dot"></span>File browser</a>
+                </div>
+            </div>
             <p class="muted">Direct file operations using HTTP methods. All paths relative to <code>/sandbox</code>.</p>
 
             <h3 class="example-label">Read file or list directory</h3>

--- a/sandbox/tests/unit/bridge-proxy.test.ts
+++ b/sandbox/tests/unit/bridge-proxy.test.ts
@@ -1,0 +1,61 @@
+/* eslint-disable @typescript-eslint/no-floating-promises -- node:test's describe/it return promises by design */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { matchBridge, rewriteBridgeUrl } from '../../src/bridge-proxy.js';
+
+describe('matchBridge', () => {
+    const bridges = [
+        { path: '/app', target: 'http://127.0.0.1:3000/app' },
+        { path: '/app/admin', target: 'http://127.0.0.1:4000/' },
+        { path: '/other', target: 'http://127.0.0.1:5000' },
+    ];
+
+    it('returns the bridge whose path prefixes the request path', () => {
+        assert.equal(matchBridge(bridges, '/other/x')?.path, '/other');
+    });
+
+    it('prefers the longest matching prefix', () => {
+        assert.equal(matchBridge(bridges, '/app/admin/users')?.path, '/app/admin');
+        assert.equal(matchBridge(bridges, '/app/public')?.path, '/app');
+    });
+
+    it('returns null when nothing matches', () => {
+        assert.equal(matchBridge(bridges, '/nope'), null);
+        assert.equal(matchBridge([], '/app'), null);
+    });
+});
+
+describe('rewriteBridgeUrl', () => {
+    it('maps the exposed path to the target path', () => {
+        assert.equal(rewriteBridgeUrl('/app/users', '/app', '/myapp'), '/myapp/users');
+    });
+
+    it('returns the bare target path when there is no extra path', () => {
+        assert.equal(rewriteBridgeUrl('/app', '/app', '/myapp'), '/myapp');
+    });
+
+    it('preserves the query string', () => {
+        assert.equal(rewriteBridgeUrl('/app/users?a=1&b=2', '/app', '/myapp'), '/myapp/users?a=1&b=2');
+        assert.equal(rewriteBridgeUrl('/app?a=1', '/app', '/myapp'), '/myapp?a=1');
+    });
+
+    it('does not double the slash when both sides have one', () => {
+        assert.equal(rewriteBridgeUrl('/app/users', '/app', '/myapp/'), '/myapp/users');
+    });
+
+    it('inserts a slash when neither side has one', () => {
+        // Bridge path '/app' against request '/appx' yields extra path 'x';
+        // a target without a trailing slash still needs the separator.
+        assert.equal(rewriteBridgeUrl('/app/x', '/app', '/myapp'), '/myapp/x');
+    });
+
+    it('targets the root path cleanly', () => {
+        assert.equal(rewriteBridgeUrl('/app/users', '/app', '/'), '/users');
+        assert.equal(rewriteBridgeUrl('/app', '/app', '/'), '/');
+    });
+
+    it('always returns a URL starting with a slash', () => {
+        assert.equal(rewriteBridgeUrl('/app', '/app', 'relative'), '/relative');
+    });
+});

--- a/sandbox/tests/unit/exec-language.test.ts
+++ b/sandbox/tests/unit/exec-language.test.ts
@@ -1,0 +1,36 @@
+/* eslint-disable @typescript-eslint/no-floating-promises -- node:test's describe/it return promises by design */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { normalizeLanguage, SUPPORTED_LANGUAGES } from '../../src/operations.js';
+
+describe('normalizeLanguage', () => {
+    it('maps aliases to canonical languages', () => {
+        assert.equal(normalizeLanguage('js'), 'js');
+        assert.equal(normalizeLanguage('javascript'), 'js');
+        assert.equal(normalizeLanguage('ts'), 'ts');
+        assert.equal(normalizeLanguage('typescript'), 'ts');
+        assert.equal(normalizeLanguage('py'), 'py');
+        assert.equal(normalizeLanguage('python'), 'py');
+        assert.equal(normalizeLanguage('bash'), 'shell');
+        assert.equal(normalizeLanguage('sh'), 'shell');
+    });
+
+    it('is case-insensitive', () => {
+        assert.equal(normalizeLanguage('Python'), 'py');
+        assert.equal(normalizeLanguage('TYPESCRIPT'), 'ts');
+    });
+
+    it('returns null for missing or unknown languages', () => {
+        assert.equal(normalizeLanguage(undefined), null);
+        assert.equal(normalizeLanguage(''), null);
+        assert.equal(normalizeLanguage('rust'), null);
+    });
+});
+
+describe('SUPPORTED_LANGUAGES', () => {
+    it('lists every accepted alias for error messages', () => {
+        // The /exec and MCP error messages embed this list; keep it stable.
+        assert.equal(SUPPORTED_LANGUAGES, 'js, javascript, ts, typescript, py, python, bash, sh');
+    });
+});

--- a/sandbox/tests/unit/route-params.test.ts
+++ b/sandbox/tests/unit/route-params.test.ts
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/no-floating-promises -- node:test's describe/it return promises by design */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { wildcardPath } from '../../src/route-params.js';
+
+describe('wildcardPath', () => {
+    it('joins Express 5 wildcard segment arrays with slashes (regression: was comma-joined)', () => {
+        // Express 5 delivers `/fs/dir/sub/file.txt` as ['dir', 'sub', 'file.txt'];
+        // String() on that array produced 'dir,sub,file.txt' and broke nested paths.
+        assert.equal(wildcardPath(['dir', 'sub', 'file.txt']), 'dir/sub/file.txt');
+    });
+
+    it('handles a single-segment array', () => {
+        assert.equal(wildcardPath(['file.txt']), 'file.txt');
+    });
+
+    it('passes plain strings through', () => {
+        assert.equal(wildcardPath('a/b.txt'), 'a/b.txt');
+    });
+
+    it('returns the empty string for missing params', () => {
+        assert.equal(wildcardPath(undefined), '');
+        assert.equal(wildcardPath(null), '');
+        assert.equal(wildcardPath([]), '');
+    });
+});


### PR DESCRIPTION
Split the monolithic main.ts into focused modules for better maintainability and testability. Routes are now organized under `routes/` (fs, exec, mcp, bridges), shell/bridge/idle logic moved to dedicated modules, and the main file reduced to startup sequence and server wiring.

- Extract filesystem API (`/fs/*`) into `routes/fs.ts` with shared path-parameter helpers
- Extract code execution (`/exec`) and MCP (`/mcp`) endpoints into `routes/exec.ts` and `routes/mcp.ts`
- Move shell server (ttyd supervision, WebSocket proxy) to `shell-server.ts`
- Move bridge reverse-proxy logic to `bridge-proxy.ts`; bridge config stays in `bridges.ts`
- Extract idle-timeout tracking to `idle.ts` module with public API
- Move language normalization and execution dispatch to `operations.ts` for reuse
- Add unit tests for bridge matching, language normalization, and route parameters
- main.ts now reads as startup sequence → HTTP server assembly, with feature logic in dedicated modules

https://claude.ai/code/session_018RzDtc14x6oxeZtVARn4fD