### PR TITLE
Show total Actor memory in shell system info

### DIFF
--- a/sandbox/src/templates/shell.ts
+++ b/sandbox/src/templates/shell.ts
@@ -57,6 +57,13 @@ echo -e "  - Claude Code:   \$CLAUDE_CODE_VER"
 echo -e "  - Codex CLI:     \$CODEX_VER"
 echo -e "  - OpenCode:      \$OPENCODE_VER"
 echo -e "  - LLM API:       https://apify.com/apify/openrouter"
+if [ -n "\$ACTOR_MEMORY_MBYTES" ]; then
+    if [ \$((ACTOR_MEMORY_MBYTES % 1024)) -eq 0 ]; then
+        echo -e "  - Memory:        \$((ACTOR_MEMORY_MBYTES / 1024)) GB"
+    else
+        echo -e "  - Memory:        \$ACTOR_MEMORY_MBYTES MB"
+    fi
+fi
 echo -e "  - Working dir:   \$(pwd)"
 
 echo ""


### PR DESCRIPTION
- The shell welcome banner's System info now includes the run's total memory (from `ACTOR_MEMORY_MBYTES`), so users see the sandbox's allocation at a glance
- Shown as GB when it's a whole number of gigabytes, otherwise MB; omitted when running outside the platform

https://claude.ai/code/session_017u724CoxaEEq4YV3BcL43r